### PR TITLE
Add stratified grid

### DIFF
--- a/diffhalos/stratified_grid.py
+++ b/diffhalos/stratified_grid.py
@@ -1,0 +1,37 @@
+""" """
+
+from functools import partial
+
+from jax import jit as jjit
+from jax import numpy as jnp
+from jax import random as jran
+
+
+@partial(jjit, static_argnames=["n_per_dim"])
+def stratified_xy_grid(n_per_dim, ran_key):
+    """
+    Stratified grid with noise
+
+    Parameters
+    ----------
+    n_per_dim: int
+        Number of points per dimension (total = n_per_dim^2)
+
+    ran_key: jax.random.key(seed)
+
+    Returns
+    -------
+    xy_grid : array, shape (n_per_dim^2, 2)
+        0 <= x,y <= 1 for every grid element
+
+    """
+    grid_1d = (jnp.arange(n_per_dim) + 0.5) / n_per_dim
+
+    x = jnp.repeat(grid_1d, n_per_dim)
+    y = jnp.tile(grid_1d, n_per_dim)
+    xy_grid = jnp.column_stack([x, y])
+
+    uran = jran.uniform(ran_key, shape=xy_grid.shape)
+    noise = uran / n_per_dim - 0.5 / n_per_dim
+
+    return xy_grid + noise

--- a/diffhalos/tests/test_stratified_grid.py
+++ b/diffhalos/tests/test_stratified_grid.py
@@ -1,0 +1,21 @@
+""" """
+
+import numpy as np
+from jax import random as jran
+
+from .. import stratified_grid as sg
+
+
+def test_stratified_xy_grid():
+    ran_key = jran.key(0)
+    n_tests = 100
+    for n_per_dim in (5, 50, 500):
+        for __ in range(n_tests):
+            ran_key, test_key = jran.split(ran_key, 2)
+            xy_grid = sg.stratified_xy_grid(n_per_dim, test_key)
+            assert xy_grid.shape == (n_per_dim**2, 2)
+            assert np.all(xy_grid >= 0)
+            assert np.all(xy_grid <= 1)
+
+    xy_grid = sg.stratified_xy_grid(1_000, ran_key)
+    assert np.allclose(xy_grid.mean(), 0.5, atol=0.1)


### PR DESCRIPTION
This PR brings `stratified_grid.py`, which can be used as a fully differentiable replacement of a Sobol sequence in the generation of weighted halo lightcones.

@georgezch could you try integrating this into a new version of the Sobol lightcone generator so that people can differentiate through the weighted lightcone generation?