### PR TITLE
Bug report of `mc_lightcone_host_halo` function

### DIFF
--- a/diffhalos/lightcone/mc_lightcone_halos.py
+++ b/diffhalos/lightcone/mc_lightcone_halos.py
@@ -34,6 +34,18 @@ __all__ = (
 )
 
 
+def mc_lc_hmf(ran_key, lgmp_min, lgmp_max, z_min, z_max, sky_area_degsq):
+    return z_halopop, logmp_halopop
+
+
+def mc_lc_halos(ran_key, lgmp_min, lgmp_max, z_min, z_max, sky_area_degsq):
+    z_halopop, logmp_halopop = mc_lc_hmf(
+        ran_key, lgmp_min, lgmp_max, z_min, z_max, sky_area_degsq
+    )
+    cenpop = mc_lightcone_host_halo(*args)
+    return cenpop
+
+
 @partial(jjit, static_argnames=("nhalos_tot",))
 def mc_lightcone_host_halo_mass_function(
     ran_key,

--- a/diffhalos/lightcone/mc_lightcone_subhalos.py
+++ b/diffhalos/lightcone/mc_lightcone_subhalos.py
@@ -25,6 +25,18 @@ DEFAULT_DIFFMAHNET_SAT_MODEL = "satflow_v2_0_64bit.eqx"
 N_LGMU_PER_HOST = 5
 
 
+def mc_lc_shmf(ran_key, lgmp_min, lgmhost, z_min, z_max, sky_area_degsq):
+    return mc_lg_mu, lgmhost_pop, host_halo_indx
+
+
+def mc_lc_subhalos(ran_key, lgmp_min, lgmp_max, z_min, z_max, sky_area_degsq):
+    z_halopop, logmp_halopop = mc_lc_hmf(
+        ran_key, lgmp_min, lgmp_max, z_min, z_max, sky_area_degsq
+    )
+    cenpop = mc_lightcone_host_halo(*args)
+    return cenpop
+
+
 @partial(jjit, static_argnames=("nsub_tot",))
 def mc_lightcone_subhalo_mass_function(
     ran_key,

--- a/diffhalos/lightcone/tests/test_mc_lightcone_halos.py
+++ b/diffhalos/lightcone/tests/test_mc_lightcone_halos.py
@@ -338,3 +338,20 @@ def test_mc_lightcone_host_halo_alt_mf_params():
         # Some halos with logmp_obs<lgmp_min is ok,
         # but too many indicates an issue with diffmahnet replicating logmp_obs
         assert np.mean(cenpop.logmp_obs < lgmp_min) < 0.2, f"z_min={z_min:.2f}"
+
+
+def test_mc_lightcone_host_halo_lgmp_max():
+    """Regression test enforcing that mc_lightcone_host_halo returns some halos with
+    mass that is close to lgmp_max.
+    """
+    nhalos_tot = 2_000
+    z_min, z_max = 0.4, 2.0
+    lgmp_min, lgmp_max = 10.5, 15.5
+
+    z_grid = np.linspace(z_min, z_max, 100)
+    ran_key = jran.key(0)
+
+    sky_area_degsq = 100.0
+    args = (ran_key, lgmp_min, z_grid, sky_area_degsq, nhalos_tot)
+    cenpop = mclh.mc_lightcone_host_halo(*args, lgmp_max=lgmp_max)
+    assert np.any(cenpop.logmp_obs.max() > lgmp_max - 0.5)


### PR DESCRIPTION
The function `mc_lightcone_halos.mc_lightcone_host_halo` appears to generate halo populations in which the most massive halo has mass far below the requested value of `lgmp_max`.