### PR TITLE
Revise and extend `mc_lightcone`

### DIFF
--- a/diffhalos/__init__.py
+++ b/diffhalos/__init__.py
@@ -4,5 +4,5 @@
 
 from ._version import __version__
 from .defaults import LOGT0_GYR, T0_GYR
-from .lightcone import weighted_lc
+from .lightcone_generators import weighted_lc, weighted_lc_halos
 from .utils import redshift_mass_grid

--- a/diffhalos/lightcone/mc_lightcone.py
+++ b/diffhalos/lightcone/mc_lightcone.py
@@ -7,13 +7,12 @@ from jax import config
 
 config.update("jax_enable_x64", True)
 
-import numpy as np
 from collections import namedtuple
 
+import numpy as np
+from diffmah.diffmah_kernels import _log_mah_kern
 from jax import numpy as jnp
 from jax import random as jran
-
-from diffmah.diffmah_kernels import _log_mah_kern
 
 from ..ccshmf import DEFAULT_CCSHMF_PARAMS
 from ..cosmology import DEFAULT_COSMOLOGY

--- a/diffhalos/lightcone/mc_lightcone.py
+++ b/diffhalos/lightcone/mc_lightcone.py
@@ -7,12 +7,13 @@ from jax import config
 
 config.update("jax_enable_x64", True)
 
+import numpy as np
 from collections import namedtuple
 
-import numpy as np
-from diffmah.diffmah_kernels import _log_mah_kern
 from jax import numpy as jnp
 from jax import random as jran
+
+from diffmah.diffmah_kernels import _log_mah_kern
 
 from ..ccshmf import DEFAULT_CCSHMF_PARAMS
 from ..cosmology import DEFAULT_COSMOLOGY
@@ -410,7 +411,6 @@ def weighted_lc(
         logmp_cutoff_himass=logmp_cutoff_himass,
         centrals_model_key=centrals_model_key,
     )
-    # fields = ("z_obs", "t_obs", "logmp_obs", "mah_params", "logmp0", "logt0", "nhalos")
 
     # generate a weighted subhalo lightcone
     subpop = mclcsh.weighted_lc_subhalos(
@@ -423,9 +423,8 @@ def weighted_lc(
         logmsub_cutoff_himass=logmsub_cutoff_himass,
         subhalo_model_key=subhalo_model_key,
     )
-    # ("nsubhalos", "mah_params", "logmu_obs", "nsub_per_host")
 
-    # create the index array: [...host_indx..., ...subhalo_indx...]
+    # create the index array
     n_host = cenpop.logmp_obs.size
     n_sub = subpop.logmp_obs.size
     host_indx = jnp.arange(n_host).astype(int)
@@ -446,7 +445,7 @@ def weighted_lc(
     logmp_obs_all = jnp.concatenate((cenpop.logmp_obs, subpop.logmp_obs))
     cenpop = cenpop._replace(logmp_obs=logmp_obs_all)
 
-    # compute MAH values at z=0 for subs
+    # compute mah values at z=0 for subs
     logmp0_subs = _log_mah_kern(subpop.mah_params, 10**cenpop.logt0, cenpop.logt0)
     logmp0_all = jnp.concatenate((cenpop.logmp0, logmp0_subs))
     cenpop = cenpop._replace(logmp0=logmp0_all)

--- a/diffhalos/lightcone/mc_lightcone.py
+++ b/diffhalos/lightcone/mc_lightcone.py
@@ -440,6 +440,9 @@ def weighted_lc(
     t_obs_all = jnp.concatenate((cenpop.t_obs, t_obs_subs))
     cenpop = cenpop._replace(t_obs=t_obs_all)
 
+    nhalos_host_subs = jnp.repeat(cenpop.nhalos, subpop.nsub_per_host)
+    nhalos_host_all = jnp.concatenate((cenpop.nhalos, nhalos_host_subs))
+
     # combine halo and subhalo mah_params
     mah_params_names = cenpop.mah_params._fields
     mah_params_tot = np.zeros(
@@ -467,7 +470,8 @@ def weighted_lc(
     # this will contain all host halo information, updated to include
     # the subhalo information and some fields are updated to new shapes
     halopop = namedtuple(
-        "weighted_lc", [*cenpop._fields, "nsub_per_host", "logmu_obs", "halo_indx"]
-    )(*cenpop, subpop.nsub_per_host, logmu_obs_all, halo_indx)
+        "weighted_lc",
+        [*cenpop._fields, "nhalos_host", "nsub_per_host", "logmu_obs", "halo_indx"],
+    )(*cenpop, nhalos_host_all, subpop.nsub_per_host, logmu_obs_all, halo_indx)
 
     return halopop

--- a/diffhalos/lightcone/mc_lightcone.py
+++ b/diffhalos/lightcone/mc_lightcone.py
@@ -267,9 +267,7 @@ def mc_lc(
 
     # combine halo and subhalo mah_params
     mah_params_names = cenpop.mah_params._fields
-    mah_params_tot = np.zeros(
-        (len(mah_params_names), cenpop.logmp_obs.size + subpop.logmu_obs.size)
-    )
+    mah_params_tot = np.zeros((len(mah_params_names), n_host + n_sub))
     for i, _param in enumerate(mah_params_names):
         mah_params_tot[i, :] = np.concatenate(
             (
@@ -428,6 +426,7 @@ def weighted_lc(
 
     # create the index array: [...host_indx..., ...subhalo_indx...]
     n_host = cenpop.logmp_obs.size
+    n_sub = subpop.logmp_obs.size
     host_indx = jnp.arange(n_host).astype(int)
     subhalo_indx = jnp.repeat(host_indx, subpop.nsub_per_host)
     halo_indx = jnp.concatenate((host_indx, subhalo_indx)).astype(int)
@@ -443,11 +442,12 @@ def weighted_lc(
     nhalos_host_subs = jnp.repeat(cenpop.nhalos, subpop.nsub_per_host)
     nhalos_host_all = jnp.concatenate((cenpop.nhalos, nhalos_host_subs))
 
+    logmp_obs_all = jnp.concatenate((cenpop.logmp_obs, subpop.logmp_obs))
+    cenpop = cenpop._replace(logmp_obs=logmp_obs_all)
+
     # combine halo and subhalo mah_params
     mah_params_names = cenpop.mah_params._fields
-    mah_params_tot = np.zeros(
-        (len(mah_params_names), cenpop.logmp_obs.size + subpop.logmu_obs.size)
-    )
+    mah_params_tot = np.zeros((len(mah_params_names), n_host + n_sub))
     for i, _param in enumerate(mah_params_names):
         mah_params_tot[i, :] = np.concatenate(
             (

--- a/diffhalos/lightcone/mc_lightcone.py
+++ b/diffhalos/lightcone/mc_lightcone.py
@@ -10,6 +10,7 @@ config.update("jax_enable_x64", True)
 from collections import namedtuple
 
 import numpy as np
+from diffmah.diffmah_kernels import _log_mah_kern
 from jax import numpy as jnp
 from jax import random as jran
 
@@ -272,7 +273,7 @@ def mc_lc(
         mah_params_tot[i, :] = np.concatenate(
             (
                 cenpop.mah_params._asdict()[_param],
-                subpop.mah_params_subs._asdict()[_param],
+                subpop.mah_params._asdict()[_param],
             )
         )
     mah_params_ntup = namedtuple("mah_params", cenpop.mah_params._fields)(
@@ -422,7 +423,7 @@ def weighted_lc(
         logmsub_cutoff_himass=logmsub_cutoff_himass,
         subhalo_model_key=subhalo_model_key,
     )
-    # ("nsubhalos", "mah_params_subs", "logmu_obs", "nsub_per_host")
+    # ("nsubhalos", "mah_params", "logmu_obs", "nsub_per_host")
 
     # create the index array: [...host_indx..., ...subhalo_indx...]
     n_host = cenpop.logmp_obs.size
@@ -445,6 +446,11 @@ def weighted_lc(
     logmp_obs_all = jnp.concatenate((cenpop.logmp_obs, subpop.logmp_obs))
     cenpop = cenpop._replace(logmp_obs=logmp_obs_all)
 
+    # compute MAH values at z=0 for subs
+    logmp0_subs = _log_mah_kern(subpop.mah_params, 10**cenpop.logt0, cenpop.logt0)
+    logmp0_all = jnp.concatenate((cenpop.logmp0, logmp0_subs))
+    cenpop = cenpop._replace(logmp0=logmp0_all)
+
     # combine halo and subhalo mah_params
     mah_params_names = cenpop.mah_params._fields
     mah_params_tot = np.zeros((len(mah_params_names), n_host + n_sub))
@@ -452,7 +458,7 @@ def weighted_lc(
         mah_params_tot[i, :] = np.concatenate(
             (
                 cenpop.mah_params._asdict()[_param],
-                subpop.mah_params_subs._asdict()[_param],
+                subpop.mah_params._asdict()[_param],
             )
         )
     mah_params_ntup = namedtuple("mah_params", cenpop.mah_params._fields)(

--- a/diffhalos/lightcone/mc_lightcone.py
+++ b/diffhalos/lightcone/mc_lightcone.py
@@ -293,10 +293,13 @@ def mc_lc(
 
 def weighted_lc(
     ran_key,
-    z_obs,
-    logmp_obs,
-    lgmsub_min,
+    n_host_halos,
+    z_min,
+    z_max,
+    lgmp_min,
+    lgmp_max,
     sky_area_degsq,
+    *,
     cosmo_params=DEFAULT_COSMOLOGY,
     hmf_params=mc_hosts.DEFAULT_HMF_PARAMS,
     logmp_cutoff=mclch.DEFAULT_LOGMP_CUTOFF,
@@ -307,94 +310,165 @@ def weighted_lc(
     logmsub_cutoff_himass=mclcsh.DEFAULT_LOGMSUB_HIMASS_CUTOFF,
     centrals_model_key=mclch.DEFAULT_DIFFMAHNET_CEN_MODEL,
     subhalo_model_key=mclcsh.DEFAULT_DIFFMAHNET_SAT_MODEL,
+    lgmsub_min=None,
 ):
     """
-    Generates a weighted lightcone population of halos+subhalos with MAHs,
-    on an input grid of redshift and mass
+    Generate a mass-function-weighted lightcone of halos+subhalos and their
+    mass assembly histories.
 
     Parameters
     ----------
     ran_key: jran.key
         random key
 
-    z_obs: ndarray of shape (n_host, )
-        observed redshifts of galaxies
+    n_host_halos : int
+        Number of host halos in the weighted lightcone
 
-    logmp_obs: ndarray of shape (n_host, )
-        base-10 log of observed halo masses, in Msun
+    z_min, z_max : float
+        min/max redshift
 
-    lgmsub_min: float
-        base-10 log of the minimum mass, in Msun
+    lgmp_min,lgmp_max : float
+        log10 of min/max halo mass in units of Msun
 
     sky_area_degsq: float
-        sky area, in deg^2
+        sky area in deg^2
 
-    cosmo_params: namedtuple
+    cosmo_params: namedtuple, optional kwarg
         cosmological parameters
 
-    hmf_params: namedtuple
+    hmf_params: namedtuple, optional kwarg
         halo mass function parameters
 
-    logmp_cutoff: float
+    logmp_cutoff: float, optional kwarg
         base-10 log of minimum halo mass for which
         DiffmahPop is used to generate MAHs, in Msun;
         for logmp < logmp_cutoff, P(θ_MAH | logmp) = P(θ_MAH | logmp_cutoff)
 
-    logmp_cutoff_himass: float
+    logmp_cutoff_himass: float, optional kwarg
         base-10 log of maximum halo mass for which
         DiffmahPop is used to generate MAHs, in Msun
 
-    n_mu_per_host: int
+    n_mu_per_host: int, optional kwarg
         number of mu=Msub/Mhost values to use per host halo;
         note that for the weighted version of the lightcone,
         each host gets assigned the same number of subhalos
 
-    cshmf_params: namedtuple
+    cshmf_params: namedtuple, optional kwarg
         CCSHMF parameters
 
-    logmsub_cutoff: float
+    logmsub_cutoff: float, optional kwarg
         base-10 log of minimum subhalo mass for which
         diffmahnet is used to generate MAHs, in Msun;
         for logmsub < logmsub_cutoff, P(θ_MAH | logmsub) = P(θ_MAH | logmsub_cutoff)
 
-    logmsub_cutoff_himass: float
+    logmsub_cutoff_himass: float, optional kwarg
         base-10 log of maximum subhalo mass for which
         diffmahnet is used to generate MAHs, in Msun
 
-    centrals_model_key: str
+    centrals_model_key: str, optional kwarg
         diffmahnet model to use for centrals
 
-    subhalo_model_key: str
+    subhalo_model_key: str, optional kwarg
         diffmahnet model to use for satellites
+
+    lgmsub_min: float, optional kwarg
+        base-10 log of the minimum subhalo mass, in Msun
+        If none, will be set to lgmp_min-ε
 
     Returns
     -------
     halopop: namedtuple
-        halo population with fields:
-            z_obs: ndarray of shape (n_host, )
+        Population of n_halos_tot halos and subhalos
+            n_halos_tot = n_sub + n_host_halos
+            n_sub = nsub_per_host * n_host_halos
+
+        halopop fields:
+            z_obs: ndarray of shape (n_halos_tot, )
                 redshift values
 
-            t_obs: ndarray of shape (n_host, )
+            t_obs: ndarray of shape (n_halos_tot, )
                 cosmic time at observation, in Gyr
 
-            logmp_obs: ndarray of shape (n_host, )
+            logmp_obs: ndarray of shape (n_halos_tot, )
                 base-10 log of halo mass at observation, in Msun
 
-            mah_params: namedtuple of ndarrays of shape (n_host+n_sub, )
+            mah_params: namedtuple of ndarrays of shape (n_halos_tot, )
                 mah parameters
 
-            logmp0: ndarray of shape (n_host, )
+            logmp0: ndarray of shape (n_halos_tot, )
                 base-10 log of halo mass at z=0, in Msun
 
-            nhalos: ndarray of shape (n_host+n_sub, )
-                weighted number of halos at each grid point
+            logt0: float
+                Base-10 log of z=0 age of the Universe for the input cosmology
 
-            logmu_obs: ndarray of shape (n_sub, )
-                base-10 log of mu=Msub/Mhost for each generated subhalo
+            nhalos: ndarray of shape (n_halos_tot, )
+                weight of the (sub)halo
 
-            nsub_per_host: ndarray of shape (n_host, )
-                number of generated subhalo per host halo
+            nhalos_host: ndarray of shape (n_halos_tot, )
+                weight of the host halo
+                Equal to nhalos for central halos
+
+            nsub_per_host: int
+                number of subhalos per host halo
+                    n_sub = nsub_per_host * n_host_halos
+                    n_halos_tot = n_sub + n_host_halos
+
+            logmu_obs: ndarray of shape (n_halos_tot, )
+                base-10 log of mu=Msub/Mhost
+
+            halo_indx: ndarray of shape (n_halos_tot, )
+                index of the associated host halo
+                for central halos: halo_indx = range(n_halos_tot)
+
     """
+    lgm_key, redshift_key, halo_key = jran.split(ran_key, 3)
+    logmp_obs = jran.uniform(
+        lgm_key, minval=lgmp_min, maxval=lgmp_max, shape=(n_host_halos,)
+    )
+    z_obs = jran.uniform(
+        redshift_key, minval=z_min, maxval=z_max, shape=(n_host_halos,)
+    )
+
+    if lgmsub_min is None:
+        lgmsub_min = lgmp_min - 0.01
+
+    halopop = _weighted_lc_from_grid(
+        halo_key,
+        z_obs,
+        logmp_obs,
+        lgmsub_min,
+        sky_area_degsq,
+        cosmo_params,
+        hmf_params,
+        logmp_cutoff,
+        logmp_cutoff_himass,
+        n_mu_per_host,
+        ccshmf_params,
+        logmsub_cutoff,
+        logmsub_cutoff_himass,
+        centrals_model_key,
+        subhalo_model_key,
+    )
+    return halopop
+
+
+def _weighted_lc_from_grid(
+    ran_key,
+    z_obs,
+    logmp_obs,
+    lgmsub_min,
+    sky_area_degsq,
+    cosmo_params,
+    hmf_params,
+    logmp_cutoff,
+    logmp_cutoff_himass,
+    n_mu_per_host,
+    ccshmf_params,
+    logmsub_cutoff,
+    logmsub_cutoff_himass,
+    centrals_model_key,
+    subhalo_model_key,
+):
     # two random keys, one for the host and one for the subhalo population
     host_key, subhalo_key = jran.split(ran_key)
 

--- a/diffhalos/lightcone/mc_lightcone.py
+++ b/diffhalos/lightcone/mc_lightcone.py
@@ -7,18 +7,17 @@ from jax import config
 
 config.update("jax_enable_x64", True)
 
-import numpy as np
 from collections import namedtuple
 
+import numpy as np
 from jax import numpy as jnp
 from jax import random as jran
 
+from ..ccshmf import DEFAULT_CCSHMF_PARAMS
+from ..cosmology import DEFAULT_COSMOLOGY
+from ..hmf import mc_hosts
 from . import mc_lightcone_halos as mclch
 from . import mc_lightcone_subhalos as mclcsh
-
-from ..hmf import mc_hosts
-from ..cosmology import DEFAULT_COSMOLOGY
-from ..ccshmf import DEFAULT_CCSHMF_PARAMS
 
 __all__ = ("mc_lc_mf", "mc_lc", "weighted_lc")
 
@@ -430,9 +429,16 @@ def weighted_lc(
     # create the index array: [...host_indx..., ...subhalo_indx...]
     n_host = cenpop.logmp_obs.size
     host_indx = jnp.arange(n_host).astype(int)
-    n_sub = int(n_host * subpop.nsub_per_host)
     subhalo_indx = jnp.repeat(host_indx, subpop.nsub_per_host)
     halo_indx = jnp.concatenate((host_indx, subhalo_indx)).astype(int)
+
+    z_obs_subs = jnp.repeat(cenpop.z_obs, subpop.nsub_per_host)
+    z_obs_all = jnp.concatenate((cenpop.z_obs, z_obs_subs))
+    cenpop = cenpop._replace(z_obs=z_obs_all)
+
+    t_obs_subs = jnp.repeat(cenpop.t_obs, subpop.nsub_per_host)
+    t_obs_all = jnp.concatenate((cenpop.t_obs, t_obs_subs))
+    cenpop = cenpop._replace(t_obs=t_obs_all)
 
     # combine halo and subhalo mah_params
     mah_params_names = cenpop.mah_params._fields
@@ -454,11 +460,14 @@ def weighted_lc(
     # combine halo and subhalo weights
     cenpop = cenpop._replace(nhalos=np.concatenate((cenpop.nhalos, subpop.nsubhalos)))
 
+    logmu_obs_host = jnp.zeros(n_host)
+    logmu_obs_all = jnp.concatenate((logmu_obs_host, subpop.logmu_obs))
+
     # create the output namedtuple containing host and subhalo information;
     # this will contain all host halo information, updated to include
     # the subhalo information and some fields are updated to new shapes
     halopop = namedtuple(
         "weighted_lc", [*cenpop._fields, "nsub_per_host", "logmu_obs", "halo_indx"]
-    )(*cenpop, subpop.nsub_per_host, subpop.logmu_obs, halo_indx)
+    )(*cenpop, subpop.nsub_per_host, logmu_obs_all, halo_indx)
 
     return halopop

--- a/diffhalos/lightcone/mc_lightcone_halos.py
+++ b/diffhalos/lightcone/mc_lightcone_halos.py
@@ -5,23 +5,21 @@ from jax import config
 
 config.update("jax_enable_x64", True)
 
+from collections import namedtuple
 from functools import partial
 
-from collections import namedtuple
-
+from diffmah.diffmah_kernels import _log_mah_kern
 from jax import jit as jjit
 from jax import numpy as jnp
 from jax import random as jran
 from jax import vmap
 
-from diffmah.diffmah_kernels import _log_mah_kern
-
-from ..cosmology import flat_wcdm, DEFAULT_COSMOLOGY
+from ..cosmology import DEFAULT_COSMOLOGY, flat_wcdm
 from ..cosmology.cosmo_basics import get_tobs_from_zobs
-from ..hmf.hmf_model import halo_lightcone_weights
-from ..hmf import mc_hosts
-from ..mah.utils import apply_mah_rescaling
 from ..cosmology.geometry_utils import compute_volume_from_sky_area
+from ..hmf import mc_hosts
+from ..hmf.hmf_model import halo_lightcone_weights
+from ..mah.utils import apply_mah_rescaling
 
 N_HMF_GRID = 2_000
 DEFAULT_LOGMP_CUTOFF = 10.0

--- a/diffhalos/lightcone/mc_lightcone_halos.py
+++ b/diffhalos/lightcone/mc_lightcone_halos.py
@@ -8,12 +8,11 @@ config.update("jax_enable_x64", True)
 from collections import namedtuple
 from functools import partial
 
+from diffmah.diffmah_kernels import _log_mah_kern
 from jax import jit as jjit
 from jax import numpy as jnp
 from jax import random as jran
 from jax import vmap
-
-from diffmah.diffmah_kernels import _log_mah_kern
 
 from ..cosmology import DEFAULT_COSMOLOGY, flat_wcdm
 from ..cosmology.cosmo_basics import get_tobs_from_zobs

--- a/diffhalos/lightcone/mc_lightcone_halos.py
+++ b/diffhalos/lightcone/mc_lightcone_halos.py
@@ -8,11 +8,12 @@ config.update("jax_enable_x64", True)
 from collections import namedtuple
 from functools import partial
 
-from diffmah.diffmah_kernels import _log_mah_kern
 from jax import jit as jjit
 from jax import numpy as jnp
 from jax import random as jran
 from jax import vmap
+
+from diffmah.diffmah_kernels import _log_mah_kern
 
 from ..cosmology import DEFAULT_COSMOLOGY, flat_wcdm
 from ..cosmology.cosmo_basics import get_tobs_from_zobs
@@ -341,7 +342,7 @@ def weighted_lc_halos(
     t_obs, t_0 = get_tobs_from_zobs(z_obs, cosmo_params=cosmo_params)
     logt0 = jnp.log10(t_0)
 
-    # get rescaled mah parameters and mah's
+    # get rescaled mah parameters and mah values at t_obs
     logmp_obs_clipped = jnp.clip(logmp_obs, logmp_cutoff, logmp_cutoff_himass)
     mah_params, logmp_obs = apply_mah_rescaling(
         ran_key,
@@ -352,7 +353,7 @@ def weighted_lc_halos(
         centrals_model_key,
     )
 
-    # compute MAH values today
+    # compute mah values today
     logmp0 = _log_mah_kern(mah_params, 10**logt0, logt0)
 
     # create output namedtuple

--- a/diffhalos/lightcone/mc_lightcone_halos.py
+++ b/diffhalos/lightcone/mc_lightcone_halos.py
@@ -32,6 +32,17 @@ mc_logmp_vmap = jjit(vmap(mc_hosts._mc_host_halos_singlez_kern, in_axes=_AXES))
 
 __all__ = ("mc_lc_hmf", "mc_lc_halos", "weighted_lc_halos")
 
+_CENPOP_FIELDS = (
+    "z_obs",
+    "t_obs",
+    "logmp_obs",
+    "mah_params",
+    "logmp0",
+    "logt0",
+    "nhalos",
+)
+CenPop = namedtuple("CenPop", _CENPOP_FIELDS)
+
 
 def mc_lc_hmf(
     ran_key,
@@ -356,8 +367,7 @@ def weighted_lc_halos(
     logmp0 = _log_mah_kern(mah_params, 10**logt0, logt0)
 
     # create output namedtuple
-    fields = ("z_obs", "t_obs", "logmp_obs", "mah_params", "logmp0", "logt0", "nhalos")
     values = (z_obs, t_obs, logmp_obs, mah_params, logmp0, logt0, nhalo_weights)
-    cenpop = namedtuple("cenpop", fields)(*values)
+    cenpop = CenPop(*values)
 
     return cenpop

--- a/diffhalos/lightcone/mc_lightcone_subhalos.py
+++ b/diffhalos/lightcone/mc_lightcone_subhalos.py
@@ -163,7 +163,7 @@ def mc_lc_subhalos(
     mc_lg_mu = logmsub_obs - jnp.repeat(cenpop.logmp_obs, n_mu_per_host)
 
     # add the subhalo data to the halo population namedtuple
-    fields = ("nsub_per_host", "mah_params_subs", "logmu_obs")
+    fields = ("nsub_per_host", "mah_params", "logmu_obs")
     data = (n_mu_per_host, mah_params_subs, mc_lg_mu)
     subpop = namedtuple("subpop", fields)(*data)
 
@@ -279,7 +279,7 @@ def weighted_lc_subhalos(
     # add subhalo weights to the dictionary
     fields = (
         "nsubhalos",
-        "mah_params_subs",
+        "mah_params",
         "logmu_obs",
         "logmp_obs",
         "nsub_per_host",

--- a/diffhalos/lightcone/mc_lightcone_subhalos.py
+++ b/diffhalos/lightcone/mc_lightcone_subhalos.py
@@ -5,15 +5,15 @@ from jax import config
 
 config.update("jax_enable_x64", True)
 
+from collections import namedtuple
+from functools import partial
+
 from jax import jit as jjit
 from jax import numpy as jnp
 from jax import random as jran
 
-from collections import namedtuple
-from functools import partial
-
+from ..ccshmf.ccshmf_model import DEFAULT_CCSHMF_PARAMS, subhalo_lightcone_weights
 from ..ccshmf.mc_subs import generate_subhalopop
-from ..ccshmf.ccshmf_model import subhalo_lightcone_weights, DEFAULT_CCSHMF_PARAMS
 from ..mah.utils import apply_mah_rescaling
 from ..utils.namedtuple_utils import add_field_to_namedtuple
 

--- a/diffhalos/lightcone/mc_lightcone_subhalos.py
+++ b/diffhalos/lightcone/mc_lightcone_subhalos.py
@@ -15,7 +15,6 @@ from jax import random as jran
 from ..ccshmf.ccshmf_model import DEFAULT_CCSHMF_PARAMS, subhalo_lightcone_weights
 from ..ccshmf.mc_subs import generate_subhalopop
 from ..mah.utils import apply_mah_rescaling
-from ..utils.namedtuple_utils import add_field_to_namedtuple
 
 __all__ = ("mc_lc_shmf", "mc_lc_subhalos", "weighted_lc_subhalos")
 
@@ -237,6 +236,9 @@ def weighted_lc_subhalos(
             logmu_obs: ndarray of shape (n_subs, )
                 base-10 log of mu=Msub/Mhost for each subhalo in the lightcone
 
+            logmp_obs: ndarray of shape (n_subs, )
+                base-10 log of Mpeak/Msun of each subhalo
+
             nsub_per_host: int
                 number of subhalo points generated per host halo
     """
@@ -275,8 +277,14 @@ def weighted_lc_subhalos(
     logmu_obs = logmsub_obs - jnp.repeat(cenpop.logmp_obs, n_mu_per_host)
 
     # add subhalo weights to the dictionary
-    fields = ("nsubhalos", "mah_params_subs", "logmu_obs", "nsub_per_host")
-    data = (nsubhalo_weights, mah_params_subs, logmu_obs, n_mu_per_host)
+    fields = (
+        "nsubhalos",
+        "mah_params_subs",
+        "logmu_obs",
+        "logmp_obs",
+        "nsub_per_host",
+    )
+    data = (nsubhalo_weights, mah_params_subs, logmu_obs, logmsub_obs, n_mu_per_host)
     subpop = namedtuple("subpop", fields)(*data)
 
     return subpop

--- a/diffhalos/lightcone/mc_lightcone_subhalos.py
+++ b/diffhalos/lightcone/mc_lightcone_subhalos.py
@@ -260,8 +260,7 @@ def weighted_lc_subhalos(
     logmsub_obs = lgmu + jnp.repeat(cenpop.logmp_obs, n_mu_per_host)
     t_obs = jnp.repeat(cenpop.t_obs, n_mu_per_host)
 
-    #################
-    # get the rescaled mah parameters and mah's
+    # get the rescaled mah parameters and mah values at t_obs
     logmsub_obs_clipped = jnp.clip(logmsub_obs, logmsub_cutoff, logmsub_cutoff_himass)
     mah_params_subs, logmsub_obs = apply_mah_rescaling(
         ran_key,
@@ -271,19 +270,12 @@ def weighted_lc_subhalos(
         cenpop.logt0,
         subhalo_model_key,
     )
-    #################
 
-    # compute the rescaled mu values
+    # compute the rescaled mu values at t_obs
     logmu_obs = logmsub_obs - jnp.repeat(cenpop.logmp_obs, n_mu_per_host)
 
     # add subhalo weights to the dictionary
-    fields = (
-        "nsubhalos",
-        "mah_params",
-        "logmu_obs",
-        "logmp_obs",
-        "nsub_per_host",
-    )
+    fields = ("nsubhalos", "mah_params", "logmu_obs", "logmp_obs", "nsub_per_host")
     data = (nsubhalo_weights, mah_params_subs, logmu_obs, logmsub_obs, n_mu_per_host)
     subpop = namedtuple("subpop", fields)(*data)
 

--- a/diffhalos/lightcone/tests/test_mc_lightcone.py
+++ b/diffhalos/lightcone/tests/test_mc_lightcone.py
@@ -115,3 +115,33 @@ def test_weighted_lc_behaves_as_expected():
     assert np.isfinite(halopop.logt0)
     assert halopop.nsub_per_host.shape == ()
     assert np.isfinite(halopop.nsub_per_host)
+
+
+def test_weighted_lc_logmp0_is_consistent_with_logmp_obs():
+    """Enforce self-consistent behavior for logmp0 and logmp_obs columns
+    centrals: logmp_obs <= logmp0
+    satellites: logmp_obs == logmp0
+
+    """
+    ran_key = jran.key(0)
+
+    n_host = 100
+    z_obs = np.linspace(0.2, 1.5, n_host)
+    logmp_obs = np.linspace(11.0, 14.0, n_host)
+
+    lgmsub_min = 10.0
+    sky_area_degsq = 10.0
+
+    halopop = mclc.weighted_lc(
+        ran_key,
+        z_obs,
+        logmp_obs,
+        lgmsub_min,
+        sky_area_degsq,
+    )
+
+    # centrals: logmp_obs <= logmp0
+    assert np.all(halopop.logmp0[:n_host] >= halopop.logmp_obs[:n_host])
+
+    # satellites: logmp_obs == logmp0
+    assert np.allclose(halopop.logmp0[n_host:], halopop.logmp_obs[n_host:])

--- a/diffhalos/lightcone/tests/test_mc_lightcone.py
+++ b/diffhalos/lightcone/tests/test_mc_lightcone.py
@@ -145,3 +145,33 @@ def test_weighted_lc_logmp0_is_consistent_with_logmp_obs():
 
     # satellites: logmp_obs == logmp0
     assert np.allclose(halopop.logmp0[n_host:], halopop.logmp_obs[n_host:])
+
+
+def test_weighted_lc_tpeak_subs():
+    """Enforce self-consistent behavior for logmp0 and logmp_obs columns
+    centrals: logmp_obs <= logmp0
+    satellites: logmp_obs == logmp0
+
+    """
+    ran_key = jran.key(0)
+
+    n_host = 100
+    z_obs = np.linspace(0.2, 1.5, n_host)
+    logmp_obs = np.linspace(11.0, 14.0, n_host)
+
+    lgmsub_min = 10.0
+    sky_area_degsq = 10.0
+
+    halopop = mclc.weighted_lc(
+        ran_key,
+        z_obs,
+        logmp_obs,
+        lgmsub_min,
+        sky_area_degsq,
+    )
+
+    # satellites: t_peak <= t_obs
+    assert np.all(halopop.mah_params.t_peak[n_host:] <= halopop.t_obs[n_host:])
+
+    # at least SOME satellites should have t_peak != t_obs
+    assert np.any(halopop.mah_params.t_peak[n_host:] < halopop.t_obs[n_host:])

--- a/diffhalos/lightcone/tests/test_mc_lightcone.py
+++ b/diffhalos/lightcone/tests/test_mc_lightcone.py
@@ -78,8 +78,9 @@ def test_mc_lc_behaves_as_expected():
 def test_weighted_lc_behaves_as_expected():
     ran_key = jran.key(0)
 
-    z_obs = np.linspace(0.2, 1.5, 100)
-    logmp_obs = np.linspace(11.0, 14.0, 100)
+    n_host = 100
+    z_obs = np.linspace(0.2, 1.5, n_host)
+    logmp_obs = np.linspace(11.0, 14.0, n_host)
 
     lgmsub_min = 10.0
     sky_area_degsq = 10.0
@@ -95,7 +96,6 @@ def test_weighted_lc_behaves_as_expected():
     for _field in halopop._fields:
         assert np.all(np.isfinite(halopop._asdict()[_field]))
 
-    n_host = halopop.logmp_obs.size
     n_subs = n_host * halopop.nsub_per_host
     n_tot = n_host + n_subs
     for _param in halopop.mah_params._fields:

--- a/diffhalos/lightcone/tests/test_mc_lightcone.py
+++ b/diffhalos/lightcone/tests/test_mc_lightcone.py
@@ -1,18 +1,17 @@
 """ """
 
 import numpy as np
-
-from jax import random as jran
+from diffmah.diffmah_kernels import _log_mah_kern
 from jax import numpy as jnp
+from jax import random as jran
 
+from ...ccshmf.ccshmf_model import subhalo_lightcone_weights
 from ...ccshmf.utils import match_cenpop_to_subpop
+from ...mah.diffmahnet.diffmahnet import log_mah_kern
+from ...mah.diffmahnet_utils import mc_mah_cenpop
 from .. import mc_lightcone as mclc
 from .. import mc_lightcone_halos as mclch
 from .. import mc_lightcone_subhalos as mclcsh
-from ...mah.diffmahnet.diffmahnet import log_mah_kern
-from ...mah.diffmahnet_utils import mc_mah_cenpop
-from ...ccshmf.ccshmf_model import subhalo_lightcone_weights
-from diffmah.diffmah_kernels import _log_mah_kern
 
 
 def test_mc_lc_mf_behaves_as_expected():
@@ -87,23 +86,15 @@ def test_weighted_lc_behaves_as_expected():
     """Check each returned column is finite and has the expected shape"""
     ran_key = jran.key(0)
 
-    n_host = 100
-    z_obs = np.linspace(0.2, 1.5, n_host)
-    logmp_obs = np.linspace(11.0, 14.0, n_host)
-
-    lgmsub_min = 10.0
+    n_host_halos = 100
+    z_min, z_max = 0.1, 3.1
     sky_area_degsq = 10.0
+    lgmp_min, lgmp_max = 10.0, 15.0
+    args = (ran_key, n_host_halos, z_min, z_max, lgmp_min, lgmp_max, sky_area_degsq)
+    halopop = mclc.weighted_lc(*args)
 
-    halopop = mclc.weighted_lc(
-        ran_key,
-        z_obs,
-        logmp_obs,
-        lgmsub_min,
-        sky_area_degsq,
-    )
-
-    n_subs = n_host * halopop.nsub_per_host
-    n_tot = n_host + n_subs
+    n_subs = n_host_halos * halopop.nsub_per_host
+    n_tot = n_host_halos + n_subs
 
     # Check mah_params for shape and finite
     assert len(halopop.mah_params) == 5
@@ -133,31 +124,23 @@ def test_weighted_lc_logmp0_is_consistent_with_logmp_obs():
     """
     ran_key = jran.key(0)
 
-    n_host = 100
-    z_obs = np.linspace(0.2, 1.5, n_host)
-    logmp_obs = np.linspace(11.0, 14.0, n_host)
-
-    lgmsub_min = 10.0
+    n_host_halos = 100
+    z_min, z_max = 0.1, 3.1
     sky_area_degsq = 10.0
-
-    halopop = mclc.weighted_lc(
-        ran_key,
-        z_obs,
-        logmp_obs,
-        lgmsub_min,
-        sky_area_degsq,
-    )
+    lgmp_min, lgmp_max = 10.0, 15.0
+    args = (ran_key, n_host_halos, z_min, z_max, lgmp_min, lgmp_max, sky_area_degsq)
+    halopop = mclc.weighted_lc(*args)
 
     # centrals: logmp_obs <= logmp0
-    assert np.all(halopop.logmp0[:n_host] >= halopop.logmp_obs[:n_host])
+    assert np.all(halopop.logmp0[:n_host_halos] >= halopop.logmp_obs[:n_host_halos])
 
     # satellites: logmp_obs == logmp0
     _filter_t_peak_t_obs = np.where(
-        halopop.t_obs[n_host:] > halopop.mah_params.t_peak[n_host:]
+        halopop.t_obs[n_host_halos:] > halopop.mah_params.t_peak[n_host_halos:]
     )[0]
     assert np.allclose(
-        halopop.logmp0[n_host:][_filter_t_peak_t_obs],
-        halopop.logmp_obs[n_host:][_filter_t_peak_t_obs],
+        halopop.logmp0[n_host_halos:][_filter_t_peak_t_obs],
+        halopop.logmp_obs[n_host_halos:][_filter_t_peak_t_obs],
     )
 
 
@@ -168,35 +151,30 @@ def test_weighted_lc_tpeak_subs():
     """
     ran_key = jran.key(0)
 
-    n_host = 100
-    z_obs = np.linspace(0.2, 1.5, n_host)
-    logmp_obs = np.linspace(11.0, 14.0, n_host)
-
-    lgmsub_min = 10.0
+    n_host_halos = 1000
+    z_min, z_max = 0.1, 3.1
     sky_area_degsq = 10.0
-
-    halopop = mclc.weighted_lc(
-        ran_key,
-        z_obs,
-        logmp_obs,
-        lgmsub_min,
-        sky_area_degsq,
-    )
+    lgmp_min, lgmp_max = 10.0, 15.0
+    args = (ran_key, n_host_halos, z_min, z_max, lgmp_min, lgmp_max, sky_area_degsq)
+    halopop = mclc.weighted_lc(*args)
 
     # satellites: t_peak <= t_obs
     # ensure that the fraction of subs for which this is false is < 10%
     _filter_t_peak_t_obs = np.where(
-        halopop.t_obs[n_host:] < halopop.mah_params.t_peak[n_host:]
+        halopop.t_obs[n_host_halos:] < halopop.mah_params.t_peak[n_host_halos:]
     )[0]
-    assert len(_filter_t_peak_t_obs) / float(halopop.nsub_per_host * n_host) < 0.1
+    tol = 0.15
+    assert len(_filter_t_peak_t_obs) / float(halopop.nsub_per_host * n_host_halos) < tol
 
     # at least SOME satellites should have t_peak != t_obs
-    assert np.any(halopop.mah_params.t_peak[n_host:] != halopop.t_obs[n_host:])
+    assert np.any(
+        halopop.mah_params.t_peak[n_host_halos:] != halopop.t_obs[n_host_halos:]
+    )
 
     # make sure it is the same subhalos that have t_peak>t_obs and logm_obs!=logm0
-    _filter_m_obs_m0 = np.where(halopop.logmp0[n_host:] != halopop.logmp_obs[n_host:])[
-        0
-    ]
+    _filter_m_obs_m0 = np.where(
+        halopop.logmp0[n_host_halos:] != halopop.logmp_obs[n_host_halos:]
+    )[0]
     assert np.all(_filter_m_obs_m0 == _filter_t_peak_t_obs)
 
 

--- a/diffhalos/lightcone/tests/test_mc_lightcone.py
+++ b/diffhalos/lightcone/tests/test_mc_lightcone.py
@@ -1,10 +1,18 @@
 """ """
 
 import numpy as np
+
 from jax import random as jran
+from jax import numpy as jnp
 
 from ...ccshmf.utils import match_cenpop_to_subpop
 from .. import mc_lightcone as mclc
+from .. import mc_lightcone_halos as mclch
+from .. import mc_lightcone_subhalos as mclcsh
+from ...mah.diffmahnet.diffmahnet import log_mah_kern
+from ...mah.diffmahnet_utils import mc_mah_cenpop
+from ...ccshmf.ccshmf_model import subhalo_lightcone_weights
+from diffmah.diffmah_kernels import _log_mah_kern
 
 
 def test_mc_lc_mf_behaves_as_expected():
@@ -121,7 +129,7 @@ def test_weighted_lc_logmp0_is_consistent_with_logmp_obs():
     """Enforce self-consistent behavior for logmp0 and logmp_obs columns
     centrals: logmp_obs <= logmp0
     satellites: logmp_obs == logmp0
-
+    We perform these checks only for subhalos with t_peak < t_obs
     """
     ran_key = jran.key(0)
 
@@ -144,14 +152,19 @@ def test_weighted_lc_logmp0_is_consistent_with_logmp_obs():
     assert np.all(halopop.logmp0[:n_host] >= halopop.logmp_obs[:n_host])
 
     # satellites: logmp_obs == logmp0
-    assert np.allclose(halopop.logmp0[n_host:], halopop.logmp_obs[n_host:])
+    _filter_t_peak_t_obs = np.where(
+        halopop.t_obs[n_host:] > halopop.mah_params.t_peak[n_host:]
+    )[0]
+    assert np.allclose(
+        halopop.logmp0[n_host:][_filter_t_peak_t_obs],
+        halopop.logmp_obs[n_host:][_filter_t_peak_t_obs],
+    )
 
 
 def test_weighted_lc_tpeak_subs():
-    """Enforce self-consistent behavior for logmp0 and logmp_obs columns
-    centrals: logmp_obs <= logmp0
-    satellites: logmp_obs == logmp0
-
+    """Enforce self-consistent behavior for t_peak and t_obs columns
+    satellites: t_peak <= t_obs
+    for at least some satellites: t_peak != t_obs
     """
     ran_key = jran.key(0)
 
@@ -171,7 +184,93 @@ def test_weighted_lc_tpeak_subs():
     )
 
     # satellites: t_peak <= t_obs
-    assert np.all(halopop.mah_params.t_peak[n_host:] <= halopop.t_obs[n_host:])
+    # ensure that the fraction of subs for which this is false is < 10%
+    _filter_t_peak_t_obs = np.where(
+        halopop.t_obs[n_host:] < halopop.mah_params.t_peak[n_host:]
+    )[0]
+    assert len(_filter_t_peak_t_obs) / float(halopop.nsub_per_host * n_host) < 0.1
 
     # at least SOME satellites should have t_peak != t_obs
-    assert np.any(halopop.mah_params.t_peak[n_host:] < halopop.t_obs[n_host:])
+    assert np.any(halopop.mah_params.t_peak[n_host:] != halopop.t_obs[n_host:])
+
+    # make sure it is the same subhalos that have t_peak>t_obs and logm_obs!=logm0
+    _filter_m_obs_m0 = np.where(halopop.logmp0[n_host:] != halopop.logmp_obs[n_host:])[
+        0
+    ]
+    assert np.all(_filter_m_obs_m0 == _filter_t_peak_t_obs)
+
+
+def test_weighted_lc_tpeak_clip():
+    """Enforce self-consistent behavior for t_peak and t_obs columns
+    satellites: t_peak <= t_obs
+    by clipping t_peak at t_obs in the diffmahnet parameters
+    """
+    ran_key = jran.key(0)
+    cen_key, sub_key = jran.split(ran_key, 2)
+
+    n_host = 100
+    z_obs = np.linspace(0.2, 1.5, n_host)
+    logmp_obs = np.linspace(11.0, 14.0, n_host)
+
+    lgmsub_min = 10.0
+    sky_area_degsq = 10.0
+
+    cenpop = mclch.weighted_lc_halos(
+        cen_key,
+        z_obs,
+        logmp_obs,
+        sky_area_degsq,
+    )
+
+    # number of host halos
+    n_host = cenpop.logmp_obs.size
+
+    # get mu values
+    lgmu = subhalo_lightcone_weights(
+        cenpop.logmp_obs,
+        lgmsub_min,
+        mclcsh.N_LGMU_PER_HOST,
+        mclcsh.DEFAULT_CCSHMF_PARAMS,
+    )[1].reshape(n_host * mclcsh.N_LGMU_PER_HOST)
+
+    # get the subhalo mass and time of observation for MAH computations
+    logmsub_obs = lgmu + jnp.repeat(cenpop.logmp_obs, mclcsh.N_LGMU_PER_HOST)
+    t_obs = jnp.repeat(cenpop.t_obs, mclcsh.N_LGMU_PER_HOST)
+
+    # get the rescaled mah parameters and mah values at t_obs
+    logmsub_obs_clipped = jnp.clip(
+        logmsub_obs, mclcsh.DEFAULT_LOGMSUB_CUTOFF, mclcsh.DEFAULT_LOGMSUB_HIMASS_CUTOFF
+    )
+    mah_params_uncorrected = mc_mah_cenpop(
+        logmsub_obs_clipped,
+        t_obs,
+        sub_key,
+        mclcsh.DEFAULT_DIFFMAHNET_SAT_MODEL,
+    )
+
+    # clip t_peak values for subs's mah parameters
+    t_peak_clip = jnp.clip(mah_params_uncorrected.t_peak, 0.0, t_obs)
+    mah_params_uncorrected = mah_params_uncorrected._replace(t_peak=t_peak_clip)
+
+    # compute the uncorrected observed masses
+    logmp_obs_uncorrected = log_mah_kern(mah_params_uncorrected, t_obs, cenpop.logt0)
+
+    # rescale the mah parameters to the correct logm0
+    delta_logm_obs = logmp_obs_uncorrected - logmsub_obs
+    logm0_rescaled = mah_params_uncorrected.logm0 - delta_logm_obs
+    mah_params_subs = mah_params_uncorrected._replace(logm0=logm0_rescaled)
+
+    # compute observed mass with corrected parameters
+    logmsub_obs = log_mah_kern(mah_params_subs, t_obs, cenpop.logt0)
+
+    # compute mass of subs at z=0
+    logmp0_subs = _log_mah_kern(mah_params_subs, 10**cenpop.logt0, cenpop.logt0)
+
+    # satellites: t_peak <= t_obs
+    assert np.all(mah_params_subs.t_peak <= t_obs)
+
+    # at least SOME satellites should have t_peak != t_obs
+    assert np.any(mah_params_subs.t_peak != t_obs)
+
+    # satellites: logmp_obs == logmp0
+    assert np.allclose(logmp0_subs, logmsub_obs)

--- a/diffhalos/lightcone/tests/test_mc_lightcone.py
+++ b/diffhalos/lightcone/tests/test_mc_lightcone.py
@@ -98,8 +98,8 @@ def test_weighted_lc_behaves_as_expected():
 
     n_subs = n_host * halopop.nsub_per_host
     n_tot = n_host + n_subs
-    for _param in halopop.mah_params._fields:
-        assert halopop.mah_params._asdict()[_param].size == n_tot
+    for arr in halopop.mah_params:
+        assert arr.size == n_tot
 
     assert halopop.halo_indx.size == n_tot
 

--- a/diffhalos/lightcone/tests/test_mc_lightcone.py
+++ b/diffhalos/lightcone/tests/test_mc_lightcone.py
@@ -1,11 +1,10 @@
 """ """
 
 import numpy as np
-
 from jax import random as jran
 
-from .. import mc_lightcone as mclc
 from ...ccshmf.utils import match_cenpop_to_subpop
+from .. import mc_lightcone as mclc
 
 
 def test_mc_lc_mf_behaves_as_expected():
@@ -47,7 +46,7 @@ def test_mc_lc_mf_behaves_as_expected():
     assert host_halo_indx[-1] == logmp_cenpop.size - 1
 
 
-def test_lc_mc_bahaves_as_expected():
+def test_mc_lc_behaves_as_expected():
     ran_key = jran.key(0)
 
     lgmp_min = 12.0
@@ -76,7 +75,7 @@ def test_lc_mc_bahaves_as_expected():
     assert halopop.halo_indx.size == n_host + n_subs
 
 
-def test_weighted_mc_bahaves_as_expected():
+def test_weighted_lc_behaves_as_expected():
     ran_key = jran.key(0)
 
     z_obs = np.linspace(0.2, 1.5, 100)

--- a/diffhalos/lightcone/tests/test_mc_lightcone.py
+++ b/diffhalos/lightcone/tests/test_mc_lightcone.py
@@ -76,6 +76,7 @@ def test_mc_lc_behaves_as_expected():
 
 
 def test_weighted_lc_behaves_as_expected():
+    """Check each returned column is finite and has the expected shape"""
     ran_key = jran.key(0)
 
     n_host = 100
@@ -93,16 +94,24 @@ def test_weighted_lc_behaves_as_expected():
         sky_area_degsq,
     )
 
-    for _field in halopop._fields:
-        assert np.all(np.isfinite(halopop._asdict()[_field]))
-
     n_subs = n_host * halopop.nsub_per_host
     n_tot = n_host + n_subs
+
+    # Check mah_params for shape and finite
+    assert len(halopop.mah_params) == 5
     for arr in halopop.mah_params:
-        assert arr.size == n_tot
+        assert np.all(np.isfinite(arr))
+        assert arr.shape == (n_tot,)
 
-    assert halopop.halo_indx.size == n_tot
+    # Check other columns for shape and finite
+    skip_list = ("logt0", "mah_params", "nsub_per_host")
+    for name, val in zip(halopop._fields, halopop):
+        if name not in skip_list:
+            assert val.shape == (n_tot,), name
+            assert np.all(np.isfinite(val))
 
-    assert halopop.nhalos.size == n_tot
-
-    assert halopop.logmp_obs.shape == (n_tot,)
+    # Check scalar columns for shape and finite
+    assert halopop.logt0.shape == ()
+    assert np.isfinite(halopop.logt0)
+    assert halopop.nsub_per_host.shape == ()
+    assert np.isfinite(halopop.nsub_per_host)

--- a/diffhalos/lightcone/tests/test_mc_lightcone.py
+++ b/diffhalos/lightcone/tests/test_mc_lightcone.py
@@ -97,9 +97,12 @@ def test_weighted_lc_behaves_as_expected():
 
     n_host = halopop.logmp_obs.size
     n_subs = n_host * halopop.nsub_per_host
+    n_tot = n_host + n_subs
     for _param in halopop.mah_params._fields:
-        assert halopop.mah_params._asdict()[_param].size == n_host + n_subs
+        assert halopop.mah_params._asdict()[_param].size == n_tot
 
-    assert halopop.halo_indx.size == n_host + n_subs
+    assert halopop.halo_indx.size == n_tot
 
-    assert halopop.nhalos.size == n_host + n_subs
+    assert halopop.nhalos.size == n_tot
+
+    assert halopop.logmp_obs.shape == (n_tot,)

--- a/diffhalos/lightcone/tests/test_mc_lightcone_subhalos.py
+++ b/diffhalos/lightcone/tests/test_mc_lightcone_subhalos.py
@@ -4,6 +4,8 @@ import numpy as np
 from jax import numpy as jnp
 from jax import random as jran
 
+from diffmah.diffmah_kernels import _log_mah_kern
+
 from ...ccshmf import mc_subs
 from ...ccshmf.utils import match_cenpop_to_subpop
 from ...mah.utils import apply_mah_rescaling
@@ -268,7 +270,6 @@ def test_mc_weighted_lc_subhalos_agrees_with_mc_subhalopop():
     z_max = 0.5
     logmp_min = 11.0
     logmp_max = 14.0
-    lgmp_min = 10.0
     n_cens = 2_000
 
     # use a mock host halo population for this test

--- a/diffhalos/lightcone/tests/test_mc_lightcone_subhalos.py
+++ b/diffhalos/lightcone/tests/test_mc_lightcone_subhalos.py
@@ -1,15 +1,14 @@
 """ """
 
 import numpy as np
-
-from jax import random as jran
 from jax import numpy as jnp
+from jax import random as jran
 
+from ...ccshmf import mc_subs
+from ...ccshmf.utils import match_cenpop_to_subpop
+from ...mah.utils import apply_mah_rescaling
 from .. import mc_lightcone_subhalos as mclsh
 from ..utils import generate_mock_cenpop
-from ...ccshmf import mc_subs
-from ...mah.utils import apply_mah_rescaling
-from ...ccshmf.utils import match_cenpop_to_subpop
 
 
 def test_mc_lc_shmf_works_as_expected():
@@ -95,10 +94,8 @@ def test_mc_lc_subhalos_works_as_expected():
     for _field in subpop._fields:
         assert np.all(np.isfinite(subpop._asdict()[_field]))
 
-    for _field in subpop.mah_params_subs._fields:
-        assert (
-            subpop.mah_params_subs._asdict()[_field].shape[0] == subpop.logmu_obs.size
-        )
+    for _field in subpop.mah_params._fields:
+        assert subpop.mah_params._asdict()[_field].shape[0] == subpop.logmu_obs.size
 
 
 def test_mc_lc_subhalos_vs_subpop_from_mc_subs():
@@ -220,8 +217,8 @@ def test_mc_weighted_lc_subhalos_behaves_as_expected():
     assert host_index_for_subs.dtype == np.int64
     assert host_index_for_subs[0] == 0
     assert host_index_for_subs[-1] == n_cens - 1
-    for _key in subpop.mah_params_subs._fields:
-        assert subpop.mah_params_subs._asdict()[_key].size == n_cens * n_sub_per_host
+    for arr in subpop.mah_params:
+        assert arr.size == n_cens * n_sub_per_host
 
 
 def test_mc_weighted_lc_subhalos_with_different_nsubs_per_host():
@@ -259,8 +256,8 @@ def test_mc_weighted_lc_subhalos_with_different_nsubs_per_host():
     assert host_index_for_subs.dtype == np.int64
     assert host_index_for_subs[0] == 0
     assert host_index_for_subs[-1] == n_cens - 1
-    for _key in subpop.mah_params_subs._fields:
-        assert subpop.mah_params_subs._asdict()[_key].size == n_cens * n_sub_per_host
+    for _key in subpop.mah_params._fields:
+        assert subpop.mah_params._asdict()[_key].size == n_cens * n_sub_per_host
 
 
 def test_mc_weighted_lc_subhalos_agrees_with_mc_subhalopop():

--- a/diffhalos/lightcone/tests/test_mc_lightcone_subhalos.py
+++ b/diffhalos/lightcone/tests/test_mc_lightcone_subhalos.py
@@ -4,8 +4,6 @@ import numpy as np
 from jax import numpy as jnp
 from jax import random as jran
 
-from diffmah.diffmah_kernels import _log_mah_kern
-
 from ...ccshmf import mc_subs
 from ...ccshmf.utils import match_cenpop_to_subpop
 from ...mah.utils import apply_mah_rescaling

--- a/diffhalos/lightcone/utils.py
+++ b/diffhalos/lightcone/utils.py
@@ -3,8 +3,8 @@
 from collections import namedtuple
 from functools import partial
 
-from jax import numpy as jnp
 from jax import jit as jjit
+from jax import numpy as jnp
 
 from ..cosmology import DEFAULT_COSMOLOGY
 from ..cosmology.cosmo_basics import get_tobs_from_zobs

--- a/diffhalos/lightcone_generators/__init__.py
+++ b/diffhalos/lightcone_generators/__init__.py
@@ -1,0 +1,5 @@
+# flake8:noqa
+
+from .mc_lightcone import mc_lc, mc_lc_mf, weighted_lc
+from .mc_lightcone_halos import mc_lc_halos, mc_lc_hmf, weighted_lc_halos
+from .mc_lightcone_subhalos import mc_lc_shmf, mc_lc_subhalos, weighted_lc_subhalos

--- a/diffhalos/lightcone_generators/mc_lightcone.py
+++ b/diffhalos/lightcone_generators/mc_lightcone.py
@@ -1,0 +1,555 @@
+# flake8: noqa: E402
+"""Generation of halo plus subhalo lightcones.
+This module combines the halo and subhalo lightcone generators
+and combines the outputs in a user-friendly and useful way."""
+
+from jax import config
+
+config.update("jax_enable_x64", True)
+
+from collections import namedtuple
+
+import numpy as np
+from diffmah.diffmah_kernels import _log_mah_kern
+from jax import numpy as jnp
+from jax import random as jran
+
+from ..ccshmf import DEFAULT_CCSHMF_PARAMS
+from ..cosmology import DEFAULT_COSMOLOGY
+from ..hmf import mc_hosts
+from . import mc_lightcone_halos as mclch
+from . import mc_lightcone_subhalos as mclcsh
+
+__all__ = ("mc_lc_mf", "mc_lc", "weighted_lc")
+
+
+def mc_lc_mf(
+    ran_key,
+    lgmp_min,
+    lgmsub_min,
+    z_min,
+    z_max,
+    sky_area_degsq,
+    cosmo_params=DEFAULT_COSMOLOGY,
+    hmf_params=mc_hosts.DEFAULT_HMF_PARAMS,
+    lgmp_max=mc_hosts.LGMH_MAX,
+    n_hmf_grid=mclch.N_HMF_GRID,
+    ccshmf_params=DEFAULT_CCSHMF_PARAMS,
+):
+    """
+    Generate a Monte Carlo realization of a lightcone of
+    host halos and subhalos
+
+    Parameters
+    ----------
+    ran_key: jran.key
+        random key
+
+    lgmp_min: float
+        minimum host halo mass, in Msun
+
+    lgmsub_min: float
+        minimum subhalo mass, in Msun
+
+    z_min: float
+        minimum redshift
+
+    z_max: float
+        maximum redshift
+
+    sky_area_degsq: float
+        sky area, in deg^2
+
+    cosmo_params: namedtuple
+        dsps.cosmology.flat_wcdm cosmology
+        cosmo_params = (Om0, w0, wa, h)
+
+    hmf_params: namedtuple
+        halo mass function parameters
+
+    lgmp_max: float
+        base-10 log of maximum halo mass, in Msun
+
+    n_hmf_grid: int
+        number of redshift grid points for HMF computations
+
+    ccshmf_params: namedtuple
+        CCSHMF parameters
+
+    Returns
+    -------
+    z_halopop: ndarray of shape (n_halos, )
+        redshifts distributed randomly within the lightcone volume
+
+    logmp_halopop: ndarray of shape (n_halos, )
+        halo masses derived by Monte Carlo sampling the halo mass function
+        at the appropriate redshift for each point
+    """
+    # two random keys, one for the host and one for the subhalo population
+    host_key, subhalo_key = jran.split(ran_key)
+
+    # generate host halo MC lightcone
+    z_halopop, logmp_cenpop = mclch.mc_lc_hmf(
+        host_key,
+        lgmp_min,
+        z_min,
+        z_max,
+        sky_area_degsq,
+        cosmo_params=cosmo_params,
+        hmf_params=hmf_params,
+        lgmp_max=lgmp_max,
+        n_hmf_grid=n_hmf_grid,
+    )
+
+    # generate subhalo MC lightcone using the host halo realization
+    mc_lg_mu, subhalo_counts_per_halo = mclcsh.mc_lc_shmf(
+        subhalo_key,
+        logmp_cenpop,
+        lgmsub_min,
+        ccshmf_params=ccshmf_params,
+    )
+
+    return z_halopop, logmp_cenpop, mc_lg_mu, subhalo_counts_per_halo
+
+
+def mc_lc(
+    ran_key,
+    lgmp_min,
+    lgmsub_min,
+    z_min,
+    z_max,
+    sky_area_degsq,
+    cosmo_params=DEFAULT_COSMOLOGY,
+    hmf_params=mc_hosts.DEFAULT_HMF_PARAMS,
+    logmp_cutoff=mclch.DEFAULT_LOGMP_CUTOFF,
+    logmp_cutoff_himass=mclch.DEFAULT_LOGMP_HIMASS_CUTOFF,
+    lgmp_max=mc_hosts.LGMH_MAX,
+    n_hmf_grid=mclch.N_HMF_GRID,
+    ccshmf_params=DEFAULT_CCSHMF_PARAMS,
+    logmsub_cutoff=mclcsh.DEFAULT_LOGMSUB_CUTOFF,
+    logmsub_cutoff_himass=mclcsh.DEFAULT_LOGMSUB_HIMASS_CUTOFF,
+    centrals_model_key=mclch.DEFAULT_DIFFMAHNET_CEN_MODEL,
+    subhalo_model_key=mclcsh.DEFAULT_DIFFMAHNET_SAT_MODEL,
+):
+    """
+    Generate a halo+subhalo lightcone, including MAHs,
+    between a minimum and a maximum value of redshift and halo mass
+
+    Parameters
+    ----------
+    ran_key: jran.key
+        random key
+
+    lgmp_min: float
+        minimum halo mass, in Msun
+
+    lgmsub_min: float
+        base-10 log of the minimum mass, in Msun
+
+    z_min: float
+        minimum redshift
+
+    z_max: float
+        maximum redshift
+
+    sky_area_degsq: float
+        sky area, in deg^2
+
+    nhalos_tot: int
+        total number of halos to generate in the lightcone
+
+    cosmo_params: namedtuple
+        dsps.cosmology.flat_wcdm cosmology
+        cosmo_params = (Om0, w0, wa, h)
+
+    hmf_params: namedtuple
+        halo mass function parameters
+
+    logmp_cutoff: float
+        base-10 log of minimum halo mass for which
+        diffmahnet is used to generate MAHs, in Msun;
+        for logmp < logmp_cutoff, P(θ_MAH | logmp) = P(θ_MAH | logmp_cutoff)
+
+    logmp_cutoff_himass: float
+        base-10 log of maximum halo mass for which
+        diffmahnet is used to generate MAHs, in Msun
+
+    lgmp_max: float
+        base-10 log of maximum host halo mass, in Msun
+
+    n_hmf_grid: int
+        number of redshift grid points for HMF computations
+
+    ccshmf_params: namedtuple
+        CCSHMF parameters
+
+    logmsub_cutoff: float
+        base-10 log of minimum subhalo mass for which
+        diffmahnet is used to generate MAHs, in Msun;
+        for logmsub < logmsub_cutoff, P(θ_MAH | logmsub) = P(θ_MAH | logmsub_cutoff)
+
+    logmsub_cutoff_himass: float
+        base-10 log of maximum subhalo mass for which
+        diffmahnet is used to generate MAHs, in Msun
+
+    centrals_model_key: str
+        diffmahnet model to use for centrals
+
+    subhalo_model_key: str
+        diffmahnet model to use for satellites
+
+    Returns
+    -------
+    halopop: namedtuple
+        halo population with fields:
+            z_obs: ndarray of shape (n_host, )
+                lightcone redshift
+
+            logmp_obs: ndarray of shape (n_host, )
+                halo mass at the lightcone redshift, in Msun
+
+            mah_params: namedtuple of ndarray's with shape (n_host+n_sub, n_mah_params)
+                diffmah parameters for each host halo in the lightcone
+
+            logmp0: narray of shape (n_host, )
+                base-10 log of halo mass at z=0, in Msun
+
+            logt0: float
+                base-10 log of cosmic time at today, in Gyr
+
+            nsub_per_host: ndarray of shape (n_host, )
+                number of subhalos generated per host halo
+
+            logmu_obs: ndarray of shape (n_sub, )
+                base-10 log of mu=Msub/Mhost for each generated subhalo
+
+            halo_indx: ndarray of shape (n_host+n_sub, )
+                halo index; for host halos, the index is arange(n_host),
+                while for the subhalos, indeces correspond to the host
+                halo that hosts each generated subhalo
+    """
+    # two random keys, one for the host and one for the subhalo population
+    host_key, subhalo_key = jran.split(ran_key)
+
+    # generate a host halo lightcone
+    cenpop = mclch.mc_lc_halos(
+        host_key,
+        lgmp_min,
+        z_min,
+        z_max,
+        sky_area_degsq,
+        cosmo_params=cosmo_params,
+        hmf_params=hmf_params,
+        logmp_cutoff=logmp_cutoff,
+        logmp_cutoff_himass=logmp_cutoff_himass,
+        lgmp_max=lgmp_max,
+        n_hmf_grid=n_hmf_grid,
+        centrals_model_key=centrals_model_key,
+    )
+    # fields = ("z_obs", "t_obs", "logmp_obs", "mah_params", "logmp0", "logt0")
+
+    # generate a subhalo lightcone
+    subpop = mclcsh.mc_lc_subhalos(
+        subhalo_key,
+        cenpop,
+        lgmsub_min,
+        ccshmf_params=ccshmf_params,
+        logmsub_cutoff=logmsub_cutoff,
+        logmsub_cutoff_himass=logmsub_cutoff_himass,
+        subhalo_model_key=subhalo_model_key,
+    )
+
+    # create the index array: [...host_indx..., ...subhalo_indx...]
+    n_host = cenpop.logmp_obs.size
+    host_indx = jnp.arange(n_host).astype(int)
+    n_sub = int(subpop.nsub_per_host.sum())
+    subhalo_indx = jnp.repeat(host_indx, subpop.nsub_per_host)
+    halo_indx = jnp.concatenate((host_indx, subhalo_indx)).astype(int)
+
+    # combine halo and subhalo mah_params
+    mah_params_names = cenpop.mah_params._fields
+    mah_params_tot = np.zeros((len(mah_params_names), n_host + n_sub))
+    for i, _param in enumerate(mah_params_names):
+        mah_params_tot[i, :] = np.concatenate(
+            (
+                cenpop.mah_params._asdict()[_param],
+                subpop.mah_params._asdict()[_param],
+            )
+        )
+    mah_params_ntup = namedtuple("mah_params", cenpop.mah_params._fields)(
+        *mah_params_tot
+    )
+    cenpop = cenpop._replace(mah_params=mah_params_ntup)
+
+    # create the output namedtuple containing host and subhalo information;
+    # this will contain all host halo information, updated to include
+    # the subhalo information and some fields are updated to new shapes
+    halopop = namedtuple(
+        "mc_lc", [*cenpop._fields, "nsub_per_host", "logmu_obs", "halo_indx"]
+    )(*cenpop, subpop.nsub_per_host, subpop.logmu_obs, halo_indx)
+
+    return halopop
+
+
+def weighted_lc(
+    ran_key,
+    n_host_halos,
+    z_min,
+    z_max,
+    lgmp_min,
+    lgmp_max,
+    sky_area_degsq,
+    *,
+    cosmo_params=DEFAULT_COSMOLOGY,
+    hmf_params=mc_hosts.DEFAULT_HMF_PARAMS,
+    logmp_cutoff=mclch.DEFAULT_LOGMP_CUTOFF,
+    logmp_cutoff_himass=mclch.DEFAULT_LOGMP_HIMASS_CUTOFF,
+    n_mu_per_host=mclcsh.N_LGMU_PER_HOST,
+    ccshmf_params=mclcsh.DEFAULT_CCSHMF_PARAMS,
+    logmsub_cutoff=mclcsh.DEFAULT_LOGMSUB_CUTOFF,
+    logmsub_cutoff_himass=mclcsh.DEFAULT_LOGMSUB_HIMASS_CUTOFF,
+    centrals_model_key=mclch.DEFAULT_DIFFMAHNET_CEN_MODEL,
+    subhalo_model_key=mclcsh.DEFAULT_DIFFMAHNET_SAT_MODEL,
+    lgmsub_min=None,
+):
+    """
+    Generate a mass-function-weighted lightcone of halos+subhalos and their
+    mass assembly histories.
+
+    Parameters
+    ----------
+    ran_key: jran.key
+        random key
+
+    n_host_halos : int
+        Number of host halos in the weighted lightcone
+
+    z_min, z_max : float
+        min/max redshift
+
+    lgmp_min,lgmp_max : float
+        log10 of min/max halo mass in units of Msun
+
+    sky_area_degsq: float
+        sky area in deg^2
+
+    cosmo_params: namedtuple, optional kwarg
+        cosmological parameters
+
+    hmf_params: namedtuple, optional kwarg
+        halo mass function parameters
+
+    logmp_cutoff: float, optional kwarg
+        base-10 log of minimum halo mass for which
+        DiffmahPop is used to generate MAHs, in Msun;
+        for logmp < logmp_cutoff, P(θ_MAH | logmp) = P(θ_MAH | logmp_cutoff)
+
+    logmp_cutoff_himass: float, optional kwarg
+        base-10 log of maximum halo mass for which
+        DiffmahPop is used to generate MAHs, in Msun
+
+    n_mu_per_host: int, optional kwarg
+        number of mu=Msub/Mhost values to use per host halo;
+        note that for the weighted version of the lightcone,
+        each host gets assigned the same number of subhalos
+
+    cshmf_params: namedtuple, optional kwarg
+        CCSHMF parameters
+
+    logmsub_cutoff: float, optional kwarg
+        base-10 log of minimum subhalo mass for which
+        diffmahnet is used to generate MAHs, in Msun;
+        for logmsub < logmsub_cutoff, P(θ_MAH | logmsub) = P(θ_MAH | logmsub_cutoff)
+
+    logmsub_cutoff_himass: float, optional kwarg
+        base-10 log of maximum subhalo mass for which
+        diffmahnet is used to generate MAHs, in Msun
+
+    centrals_model_key: str, optional kwarg
+        diffmahnet model to use for centrals
+
+    subhalo_model_key: str, optional kwarg
+        diffmahnet model to use for satellites
+
+    lgmsub_min: float, optional kwarg
+        base-10 log of the minimum subhalo mass, in Msun
+        If none, will be set to lgmp_min-ε
+
+    Returns
+    -------
+    halopop: namedtuple
+        Population of n_halos_tot halos and subhalos
+            n_halos_tot = n_sub + n_host_halos
+            n_sub = nsub_per_host * n_host_halos
+
+        halopop fields:
+            z_obs: ndarray of shape (n_halos_tot, )
+                redshift values
+
+            t_obs: ndarray of shape (n_halos_tot, )
+                cosmic time at observation, in Gyr
+
+            logmp_obs: ndarray of shape (n_halos_tot, )
+                base-10 log of halo mass at observation, in Msun
+
+            mah_params: namedtuple of ndarrays of shape (n_halos_tot, )
+                mah parameters
+
+            logmp0: ndarray of shape (n_halos_tot, )
+                base-10 log of halo mass at z=0, in Msun
+
+            logt0: float
+                Base-10 log of z=0 age of the Universe for the input cosmology
+
+            nhalos: ndarray of shape (n_halos_tot, )
+                weight of the (sub)halo
+
+            nhalos_host: ndarray of shape (n_halos_tot, )
+                weight of the host halo
+                Equal to nhalos for central halos
+
+            nsub_per_host: int
+                number of subhalos per host halo
+                    n_sub = nsub_per_host * n_host_halos
+                    n_halos_tot = n_sub + n_host_halos
+
+            logmu_obs: ndarray of shape (n_halos_tot, )
+                base-10 log of mu=Msub/Mhost
+
+            halo_indx: ndarray of shape (n_halos_tot, )
+                index of the associated host halo
+                for central halos: halo_indx = range(n_halos_tot)
+
+    """
+    lgm_key, redshift_key, halo_key = jran.split(ran_key, 3)
+    logmp_obs = jran.uniform(
+        lgm_key, minval=lgmp_min, maxval=lgmp_max, shape=(n_host_halos,)
+    )
+    z_obs = jran.uniform(
+        redshift_key, minval=z_min, maxval=z_max, shape=(n_host_halos,)
+    )
+
+    if lgmsub_min is None:
+        lgmsub_min = lgmp_min - 0.01
+
+    halopop = _weighted_lc_from_grid(
+        halo_key,
+        z_obs,
+        logmp_obs,
+        lgmsub_min,
+        sky_area_degsq,
+        cosmo_params,
+        hmf_params,
+        logmp_cutoff,
+        logmp_cutoff_himass,
+        n_mu_per_host,
+        ccshmf_params,
+        logmsub_cutoff,
+        logmsub_cutoff_himass,
+        centrals_model_key,
+        subhalo_model_key,
+    )
+    return halopop
+
+
+def _weighted_lc_from_grid(
+    ran_key,
+    z_obs,
+    logmp_obs,
+    lgmsub_min,
+    sky_area_degsq,
+    cosmo_params,
+    hmf_params,
+    logmp_cutoff,
+    logmp_cutoff_himass,
+    n_mu_per_host,
+    ccshmf_params,
+    logmsub_cutoff,
+    logmsub_cutoff_himass,
+    centrals_model_key,
+    subhalo_model_key,
+):
+    # two random keys, one for the host and one for the subhalo population
+    host_key, subhalo_key = jran.split(ran_key)
+
+    # generate a weighted host halo lightcone
+    cenpop = mclch._weighted_lc_halos_from_grid(
+        host_key,
+        z_obs,
+        logmp_obs,
+        sky_area_degsq,
+        cosmo_params=cosmo_params,
+        hmf_params=hmf_params,
+        logmp_cutoff=logmp_cutoff,
+        logmp_cutoff_himass=logmp_cutoff_himass,
+        centrals_model_key=centrals_model_key,
+    )
+
+    # generate a weighted subhalo lightcone
+    subpop = mclcsh.weighted_lc_subhalos(
+        subhalo_key,
+        cenpop,
+        lgmsub_min,
+        n_mu_per_host=n_mu_per_host,
+        ccshmf_params=ccshmf_params,
+        logmsub_cutoff=logmsub_cutoff,
+        logmsub_cutoff_himass=logmsub_cutoff_himass,
+        subhalo_model_key=subhalo_model_key,
+    )
+
+    # create the index array
+    n_host = cenpop.logmp_obs.size
+    n_sub = subpop.logmp_obs.size
+    host_indx = jnp.arange(n_host).astype(int)
+    subhalo_indx = jnp.repeat(host_indx, subpop.nsub_per_host)
+    halo_indx = jnp.concatenate((host_indx, subhalo_indx)).astype(int)
+
+    z_obs_subs = jnp.repeat(cenpop.z_obs, subpop.nsub_per_host)
+    z_obs_all = jnp.concatenate((cenpop.z_obs, z_obs_subs))
+    cenpop = cenpop._replace(z_obs=z_obs_all)
+
+    t_obs_subs = jnp.repeat(cenpop.t_obs, subpop.nsub_per_host)
+    t_obs_all = jnp.concatenate((cenpop.t_obs, t_obs_subs))
+    cenpop = cenpop._replace(t_obs=t_obs_all)
+
+    nhalos_host_subs = jnp.repeat(cenpop.nhalos, subpop.nsub_per_host)
+    nhalos_host_all = jnp.concatenate((cenpop.nhalos, nhalos_host_subs))
+
+    logmp_obs_all = jnp.concatenate((cenpop.logmp_obs, subpop.logmp_obs))
+    cenpop = cenpop._replace(logmp_obs=logmp_obs_all)
+
+    # compute mah values at z=0 for subs
+    logmp0_subs = _log_mah_kern(subpop.mah_params, 10**cenpop.logt0, cenpop.logt0)
+    logmp0_all = jnp.concatenate((cenpop.logmp0, logmp0_subs))
+    cenpop = cenpop._replace(logmp0=logmp0_all)
+
+    # combine halo and subhalo mah_params
+    mah_params_names = cenpop.mah_params._fields
+    mah_params_tot = np.zeros((len(mah_params_names), n_host + n_sub))
+    for i, _param in enumerate(mah_params_names):
+        mah_params_tot[i, :] = np.concatenate(
+            (
+                cenpop.mah_params._asdict()[_param],
+                subpop.mah_params._asdict()[_param],
+            )
+        )
+    mah_params_ntup = namedtuple("mah_params", cenpop.mah_params._fields)(
+        *mah_params_tot
+    )
+    cenpop = cenpop._replace(mah_params=mah_params_ntup)
+
+    # combine halo and subhalo weights
+    cenpop = cenpop._replace(nhalos=np.concatenate((cenpop.nhalos, subpop.nsubhalos)))
+
+    logmu_obs_host = jnp.zeros(n_host)
+    logmu_obs_all = jnp.concatenate((logmu_obs_host, subpop.logmu_obs))
+
+    # create the output namedtuple containing host and subhalo information;
+    # this will contain all host halo information, updated to include
+    # the subhalo information and some fields are updated to new shapes
+    halopop = namedtuple(
+        "weighted_lc",
+        [*cenpop._fields, "nhalos_host", "nsub_per_host", "logmu_obs", "halo_indx"],
+    )(*cenpop, nhalos_host_all, subpop.nsub_per_host, logmu_obs_all, halo_indx)
+
+    return halopop

--- a/diffhalos/lightcone_generators/mc_lightcone_halos.py
+++ b/diffhalos/lightcone_generators/mc_lightcone_halos.py
@@ -1,0 +1,414 @@
+# flake8: noqa: E402
+"""Functions to generate host halo lightcones"""
+
+from jax import config
+
+config.update("jax_enable_x64", True)
+
+from collections import namedtuple
+from functools import partial
+
+from diffmah.diffmah_kernels import _log_mah_kern
+from jax import jit as jjit
+from jax import numpy as jnp
+from jax import random as jran
+from jax import vmap
+
+from ..cosmology import DEFAULT_COSMOLOGY, flat_wcdm
+from ..cosmology.cosmo_basics import get_tobs_from_zobs
+from ..cosmology.geometry_utils import compute_volume_from_sky_area
+from ..hmf import mc_hosts
+from ..hmf.hmf_model import halo_lightcone_weights
+from ..mah.utils import apply_mah_rescaling
+
+N_HMF_GRID = 2_000
+DEFAULT_LOGMP_CUTOFF = 10.0
+DEFAULT_LOGMP_HIMASS_CUTOFF = 14.5
+
+DEFAULT_DIFFMAHNET_CEN_MODEL = "cenflow_v2_0_64bit.eqx"
+
+_AXES = (0, None, None, 0, None)
+mc_logmp_vmap = jjit(vmap(mc_hosts._mc_host_halos_singlez_kern, in_axes=_AXES))
+
+__all__ = ("mc_lc_hmf", "mc_lc_halos", "weighted_lc_halos")
+
+_CENPOP_FIELDS = (
+    "z_obs",
+    "t_obs",
+    "logmp_obs",
+    "mah_params",
+    "logmp0",
+    "logt0",
+    "nhalos",
+)
+CenPop = namedtuple("CenPop", _CENPOP_FIELDS)
+
+
+def mc_lc_hmf(
+    ran_key,
+    lgmp_min,
+    z_min,
+    z_max,
+    sky_area_degsq,
+    cosmo_params=DEFAULT_COSMOLOGY,
+    hmf_params=mc_hosts.DEFAULT_HMF_PARAMS,
+    lgmp_max=mc_hosts.LGMH_MAX,
+    n_hmf_grid=N_HMF_GRID,
+):
+    """
+    Generate a Monte Carlo realization of a lightcone of
+    host halo masses and redshifts, between two redshifts
+    and between a minimum and a maximum mass
+
+    Parameters
+    ----------
+    ran_key: jran.key
+        random key
+
+    lgmp_min: float
+        minimum halo mass, in Msun
+
+    z_min: float
+        minimum redshift
+
+    z_max: float
+        maximum redshift
+
+    sky_area_degsq: float
+        sky area, in deg^2
+
+    cosmo_params: namedtuple
+        dsps.cosmology.flat_wcdm cosmology
+        cosmo_params = (Om0, w0, wa, h)
+
+    hmf_params: namedtuple
+        halo mass function parameters
+
+    lgmp_max: float
+        base-10 log of maximum halo mass, in Msun
+
+    n_hmf_grid: int
+        number of redshift grid points for HMF computations
+
+    Returns
+    -------
+    z_cenpop: ndarray of shape (n_halos, )
+        redshifts distributed randomly within the lightcone volume
+
+    logmp_cenpop: ndarray of shape (n_halos, )
+        halo masses derived by Monte Carlo sampling the halo mass function
+        at the appropriate redshift for each point
+    """
+
+    # randoms for Nhalos, halo mass, and redshift
+    halo_counts_key, m_key, z_key = jran.split(ran_key, 3)
+
+    # set up a uniform grid in redshift
+    z_grid = jnp.linspace(z_min, z_max, n_hmf_grid)
+
+    # compute the comoving volume of a thin shell at each grid point
+    volume_com_mpc = compute_volume_from_sky_area(
+        z_grid,
+        sky_area_degsq,
+        cosmo_params,
+    )
+
+    # at each grid point, compute <Nhalos> for the shell volume
+    mean_nhalos = mc_hosts._compute_nhalos_tot(
+        hmf_params,
+        lgmp_min,
+        z_grid,
+        volume_com_mpc,
+    )
+    mean_nhalos_lgmax = mc_hosts._compute_nhalos_tot(
+        hmf_params,
+        lgmp_max,
+        z_grid,
+        volume_com_mpc,
+    )
+    mean_nhalos = mean_nhalos - mean_nhalos_lgmax
+
+    # at each grid point, compute a Poisson realization of <Nhalos>
+    nhalos_tot = jran.poisson(halo_counts_key, mean_nhalos).sum()
+
+    # compute the CDF of the volume
+    weights_grid = mean_nhalos / mean_nhalos.sum()
+    cdf_grid = jnp.cumsum(weights_grid)
+
+    # assign redshift via inverse transformation sampling of the halo counts CDF
+    uran_z = jran.uniform(z_key, minval=0, maxval=1, shape=(nhalos_tot,))
+    z_cenpop = jnp.interp(uran_z, cdf_grid, z_grid)
+
+    # randoms used in inverse transformation sampling halo mass
+    uran_m = jran.uniform(m_key, minval=0, maxval=1, shape=(nhalos_tot,))
+
+    # draw a halo mass from the HMF at the particular redshift of each halo
+    logmp_cenpop = mc_logmp_vmap(uran_m, hmf_params, lgmp_min, z_cenpop, lgmp_max)
+
+    return z_cenpop, logmp_cenpop
+
+
+def mc_lc_halos(
+    ran_key,
+    lgmp_min,
+    z_min,
+    z_max,
+    sky_area_degsq,
+    cosmo_params=DEFAULT_COSMOLOGY,
+    hmf_params=mc_hosts.DEFAULT_HMF_PARAMS,
+    logmp_cutoff=DEFAULT_LOGMP_CUTOFF,
+    logmp_cutoff_himass=DEFAULT_LOGMP_HIMASS_CUTOFF,
+    lgmp_max=mc_hosts.LGMH_MAX,
+    n_hmf_grid=N_HMF_GRID,
+    centrals_model_key=DEFAULT_DIFFMAHNET_CEN_MODEL,
+):
+    """
+    Generate a halo lightcone, including MAHs,
+    between a minimum and a maximum value of redshift and halo mass
+
+    Parameters
+    ----------
+    ran_key: jran.key
+        random key
+
+    lgmp_min: float
+        minimum halo mass, in Msun
+
+    z_min: float
+        minimum redshift
+
+    z_max: float
+        maximum redshift
+
+    sky_area_degsq: float
+        sky area, in deg^2
+
+    nhalos_tot: int
+        total number of halos to generate in the lightcone
+
+    cosmo_params: namedtuple
+        dsps.cosmology.flat_wcdm cosmology
+        cosmo_params = (Om0, w0, wa, h)
+
+    hmf_params: namedtuple
+        halo mass function parameters
+
+    logmp_cutoff: float
+        base-10 log of minimum halo mass for which
+        diffmahnet is used to generate MAHs, in Msun;
+        for logmp < logmp_cutoff, P(θ_MAH | logmp) = P(θ_MAH | logmp_cutoff)
+
+    logmp_cutoff_himass: float
+        base-10 log of maximum halo mass for which
+        diffmahnet is used to generate MAHs, in Msun
+
+    lgmp_max: float
+        base-10 log of maximum host halo mass, in Msun
+
+    n_hmf_grid: int
+        number of redshift grid points for HMF computations
+
+    centrals_model_key: str
+        diffmahnet model to use for centrals
+
+    Returns
+    -------
+    cenpop: namedtuple
+        host halo population with fields:
+            z_obs: ndarray of shape (n_halos, )
+                lightcone redshift
+
+            logmp_obs: ndarray of shape (n_halos, )
+                halo mass at the lightcone redshift, in Msun
+
+            mah_params: namedtuple of ndarray's with shape (n_halos, n_mah_params)
+                diffmah parameters for each host halo in the lightcone
+
+            logmp0: narray of shape (n_halos, )
+                base-10 log of halo mass at z=0, in Msun
+
+            logt0: float
+                base-10 log of cosmic time at today, in Gyr
+    """
+
+    # generate mc realization of the halo mass function
+    lc_hmf_key, mah_key = jran.split(ran_key, 2)
+    z_obs, logmp_obs_mf = mc_lc_hmf(
+        lc_hmf_key,
+        lgmp_min,
+        z_min,
+        z_max,
+        sky_area_degsq,
+        cosmo_params=cosmo_params,
+        hmf_params=hmf_params,
+        lgmp_max=lgmp_max,
+        n_hmf_grid=n_hmf_grid,
+    )
+
+    t_obs, t_0 = get_tobs_from_zobs(z_obs, cosmo_params=cosmo_params)
+    logt0 = jnp.log10(t_0)
+
+    # get rescaled mah parameters and mah's
+    logmp_obs_clipped = jnp.clip(logmp_obs_mf, logmp_cutoff, logmp_cutoff_himass)
+    mah_params, logmp_obs = apply_mah_rescaling(
+        mah_key,
+        logmp_obs_mf,
+        logmp_obs_clipped,
+        t_obs,
+        logt0,
+        centrals_model_key,
+    )
+
+    # compute MAH values today
+    logmp0 = _log_mah_kern(mah_params, 10**logt0, logt0)
+
+    # create output namedtuple
+    fields = CenPop._fields[:-1]
+    values = (z_obs, t_obs, logmp_obs, mah_params, logmp0, logt0)
+    cenpop = namedtuple("cenpop", fields)(*values)
+
+    return cenpop
+
+
+def weighted_lc_halos(
+    ran_key,
+    n_halos,
+    z_min,
+    z_max,
+    lgmp_min,
+    lgmp_max,
+    sky_area_degsq,
+    *,
+    cosmo_params=DEFAULT_COSMOLOGY,
+    hmf_params=mc_hosts.DEFAULT_HMF_PARAMS,
+    logmp_cutoff=DEFAULT_LOGMP_CUTOFF,
+    logmp_cutoff_himass=DEFAULT_LOGMP_HIMASS_CUTOFF,
+    centrals_model_key=DEFAULT_DIFFMAHNET_CEN_MODEL,
+):
+    """
+    Generate a mass-function-weighted lightcone of halos and their
+    mass assembly histories.
+
+    Parameters
+    ----------
+    ran_key: jran.key
+        random key
+
+    n_halos : int
+        Number of host halos in the weighted lightcone
+
+    z_min, z_max : float
+        min/max redshift
+
+    lgmp_min,lgmp_max : float
+        log10 of min/max halo mass in units of Msun
+
+    sky_area_degsq: float
+        sky area in deg^2
+
+    cosmo_params: namedtuple, optional kwarg
+        cosmological parameters
+
+    hmf_params: namedtuple, optional kwarg
+        halo mass function parameters
+
+    logmp_cutoff: float, optional kwarg
+        base-10 log of minimum halo mass for which
+        DiffmahPop is used to generate MAHs, in Msun;
+        for logmp < logmp_cutoff, P(θ_MAH | logmp) = P(θ_MAH | logmp_cutoff)
+
+    logmp_cutoff_himass: float, optional kwarg
+        base-10 log of maximum halo mass for which
+        DiffmahPop is used to generate MAHs, in Msun
+
+    Returns
+    -------
+    halopop: namedtuple
+        Population of n_halos halos
+
+        halopop fields:
+            z_obs: ndarray of shape (n_halos, )
+                redshift values
+
+            t_obs: ndarray of shape (n_halos, )
+                cosmic time at observation, in Gyr
+
+            logmp_obs: ndarray of shape (n_halos, )
+                base-10 log of halo mass at observation, in Msun
+
+            mah_params: namedtuple of ndarrays of shape (n_halos, )
+                mah parameters
+
+            logmp0: ndarray of shape (n_halos, )
+                base-10 log of halo mass at z=0, in Msun
+
+            logt0: float
+                Base-10 log of z=0 age of the Universe for the input cosmology
+
+            nhalos: ndarray of shape (n_halos, )
+                weight of the (sub)halo
+
+    """
+    lgm_key, redshift_key, halo_key = jran.split(ran_key, 3)
+    logmp_obs = jran.uniform(
+        lgm_key, minval=lgmp_min, maxval=lgmp_max, shape=(n_halos,)
+    )
+    z_obs = jran.uniform(redshift_key, minval=z_min, maxval=z_max, shape=(n_halos,))
+
+    cenpop = _weighted_lc_halos_from_grid(
+        halo_key,
+        z_obs,
+        logmp_obs,
+        sky_area_degsq,
+        cosmo_params,
+        hmf_params,
+        logmp_cutoff,
+        logmp_cutoff_himass,
+        centrals_model_key,
+    )
+    return cenpop
+
+
+@partial(jjit, static_argnames=["centrals_model_key"])
+def _weighted_lc_halos_from_grid(
+    ran_key,
+    z_obs,
+    logmp_obs,
+    sky_area_degsq,
+    cosmo_params=DEFAULT_COSMOLOGY,
+    hmf_params=mc_hosts.DEFAULT_HMF_PARAMS,
+    logmp_cutoff=DEFAULT_LOGMP_CUTOFF,
+    logmp_cutoff_himass=DEFAULT_LOGMP_HIMASS_CUTOFF,
+    centrals_model_key=DEFAULT_DIFFMAHNET_CEN_MODEL,
+):
+    # get halo weights
+    nhalo_weights = halo_lightcone_weights(
+        logmp_obs,
+        z_obs,
+        sky_area_degsq,
+        hmf_params=hmf_params,
+        cosmo_params=cosmo_params,
+    )
+
+    t_obs, t_0 = get_tobs_from_zobs(z_obs, cosmo_params=cosmo_params)
+    logt0 = jnp.log10(t_0)
+
+    # get rescaled mah parameters and mah values at t_obs
+    logmp_obs_clipped = jnp.clip(logmp_obs, logmp_cutoff, logmp_cutoff_himass)
+    mah_params, logmp_obs = apply_mah_rescaling(
+        ran_key,
+        logmp_obs,
+        logmp_obs_clipped,
+        t_obs,
+        logt0,
+        centrals_model_key,
+    )
+
+    # compute mah values today
+    logmp0 = _log_mah_kern(mah_params, 10**logt0, logt0)
+
+    # create output namedtuple
+    values = (z_obs, t_obs, logmp_obs, mah_params, logmp0, logt0, nhalo_weights)
+    cenpop = CenPop(*values)
+
+    return cenpop

--- a/diffhalos/lightcone_generators/mc_lightcone_subhalos.py
+++ b/diffhalos/lightcone_generators/mc_lightcone_subhalos.py
@@ -1,0 +1,282 @@
+# flake8: noqa: E402
+"""Functions to generate subhalo lightcones"""
+
+from jax import config
+
+config.update("jax_enable_x64", True)
+
+from collections import namedtuple
+from functools import partial
+
+from jax import jit as jjit
+from jax import numpy as jnp
+from jax import random as jran
+
+from ..ccshmf.ccshmf_model import DEFAULT_CCSHMF_PARAMS, subhalo_lightcone_weights
+from ..ccshmf.mc_subs import generate_subhalopop
+from ..mah.utils import apply_mah_rescaling
+
+__all__ = ("mc_lc_shmf", "mc_lc_subhalos", "weighted_lc_subhalos")
+
+DEFAULT_DIFFMAHNET_SAT_MODEL = "satflow_v2_0_64bit.eqx"
+N_LGMU_PER_HOST = 5
+
+
+DEFAULT_LOGMSUB_CUTOFF = 10.0
+DEFAULT_LOGMSUB_HIMASS_CUTOFF = 14.5
+
+
+def mc_lc_shmf(
+    ran_key,
+    lgmhost_arr,
+    lgmsub_min,
+    ccshmf_params=DEFAULT_CCSHMF_PARAMS,
+):
+    """
+    Generate MC generalization of the subhalo mass function in a lightcone,
+    provided the masses of their host halos.
+    This function is essentially a convenient wrapper around the
+    ``mc_subs.generate_subhalopop`` function
+
+    Parameters
+    ----------
+    ran_key: jran.key
+        random key
+
+    lgmhost_arr: ndarray of shape (n_host, )
+        base-10 log of host halo mass, in Msun
+
+    lgmsub_min: float
+        base-10 log of the minimum subhalo mass, in Msub
+
+    ccshmf_params: namedtuple
+        CCSHMF parameters
+
+    Returns
+    -------
+    mc_lg_mu: ndarray of shape (n_mu, )
+        base-10 log of mu=Msub/Mhost of the Monte Carlo subhalo population
+
+    subhalo_counts_per_halo: ndarray of shape (m_hosts, )
+        number of generated subhalos per host halo
+    """
+    mc_lg_mu, subhalo_counts_per_halo = generate_subhalopop(
+        ran_key,
+        lgmhost_arr,
+        lgmsub_min,
+        ccshmf_params=ccshmf_params,
+    )
+
+    return mc_lg_mu, subhalo_counts_per_halo
+
+
+def mc_lc_subhalos(
+    ran_key,
+    cenpop,
+    lgmsub_min,
+    ccshmf_params=DEFAULT_CCSHMF_PARAMS,
+    logmsub_cutoff=DEFAULT_LOGMSUB_CUTOFF,
+    logmsub_cutoff_himass=DEFAULT_LOGMSUB_HIMASS_CUTOFF,
+    subhalo_model_key=DEFAULT_DIFFMAHNET_SAT_MODEL,
+):
+    """
+    Computes MAHs for subhalo populations,
+    based on the ``diffmahnet`` model
+
+    Parameters
+    ----------
+    ran_key: jran.key
+        random key
+
+    cenpop: namedtuple
+        host halo population, with necessary fields:
+            logmp_obs: ndarray of shape (n_host, )
+                base-10 log of halo mass at observation, in Msun
+
+            t_obs: ndarray of shape (n_host, )
+                cosmic time at observation, in Gyr
+
+            logt0: float
+                base-10 log of cosmic time at today, in Gyr
+
+    lgmsub_min: float
+        absolute minimum subhalo mass, in Msun
+
+    ccshmf_params: namedtuple
+        CCSHMF parameters
+
+    logmsub_cutoff: float
+        base-10 log of minimum subhalo mass for which
+        diffmahnet is used to generate MAHs, in Msun;
+        for logmsub < logmsub_cutoff, P(θ_MAH | logmsub) = P(θ_MAH | logmsub_cutoff)
+
+    logmsub_cutoff_himass: float
+        base-10 log of maximum subhalo mass for which
+        diffmahnet is used to generate MAHs, in Msun
+
+    subhalo_model_key: str
+        diffmahnet model to use for satellites
+
+    Returns
+    -------
+    subpop: namedtuple
+        subhalo population with fields:
+            nsub_per_host: ndarray of shape (n_host, )
+                number of generated subhalos per host halo
+
+            mah_params_subs: namedtuple of ndarray's with shape (n_subs, n_mah_params)
+                diffmah parameters for each subhalo in the lightcone
+
+            logmu_obs: ndarray of shape (n_subs, )
+                base-10 log of mu=Msub/Mhost for each subhalo in the lightcone
+    """
+
+    # two random keys, one for the MC subhalo population and one for diffmahnet
+    mu_key, mah_key = jran.split(ran_key, 2)
+
+    # generate a Poisson realization of subhalos, given the host halo population
+    mc_lg_mu_shmf, n_mu_per_host = mc_lc_shmf(
+        mu_key,
+        cenpop.logmp_obs,
+        lgmsub_min,
+        ccshmf_params=ccshmf_params,
+    )
+
+    # get the subhalo mass and time of observation for MAH computations
+    logmsub_obs_shmf = mc_lg_mu_shmf + jnp.repeat(cenpop.logmp_obs, n_mu_per_host)
+    t_obs = jnp.repeat(cenpop.t_obs, n_mu_per_host)
+
+    # get the rescaled mah parameters and mah's
+    logmsub_obs_clipped = jnp.clip(
+        logmsub_obs_shmf, logmsub_cutoff, logmsub_cutoff_himass
+    )
+    mah_params_subs, logmsub_obs = apply_mah_rescaling(
+        mah_key,
+        logmsub_obs_shmf,
+        logmsub_obs_clipped,
+        t_obs,
+        cenpop.logt0,
+        subhalo_model_key,
+    )
+
+    # compute the rescaled mu values
+    mc_lg_mu = logmsub_obs - jnp.repeat(cenpop.logmp_obs, n_mu_per_host)
+
+    # add the subhalo data to the halo population namedtuple
+    fields = ("nsub_per_host", "mah_params", "logmu_obs")
+    data = (n_mu_per_host, mah_params_subs, mc_lg_mu)
+    subpop = namedtuple("subpop", fields)(*data)
+
+    return subpop
+
+
+@partial(jjit, static_argnames=("subhalo_model_key", "n_mu_per_host"))
+def weighted_lc_subhalos(
+    ran_key,
+    cenpop,
+    lgmsub_min,
+    n_mu_per_host=N_LGMU_PER_HOST,
+    ccshmf_params=DEFAULT_CCSHMF_PARAMS,
+    logmsub_cutoff=DEFAULT_LOGMSUB_CUTOFF,
+    logmsub_cutoff_himass=DEFAULT_LOGMSUB_HIMASS_CUTOFF,
+    subhalo_model_key=DEFAULT_DIFFMAHNET_SAT_MODEL,
+):
+    """
+    Generate a subhalo lightcone
+
+    Parameters
+    ----------
+    ran_key: jran.key
+        random key
+
+    cenpop: namedtuple
+        host halo population, with necessary fields:
+            logmp_obs: ndarray of shape (n_host, )
+                base-10 log of halo mass at observation, in Msun
+
+            t_obs: ndarray of shape (n_host, )
+                cosmic time at observation, in Gyr
+
+            logt0: float
+                base-10 log of cosmic time at today, in Gyr
+
+    lgmsub_min: float
+        base-10 log of the minimum mass, in Msun
+
+    n_mu_per_host: int
+        number of mu=Msub/Mhost values to use per host halo;
+        note that for the weighted version of the lightcone,
+        each host gets assigned the same number of subhalos
+
+    cshmf_params: namedtuple
+        CCSHMF parameters
+
+    logmsub_cutoff: float
+        base-10 log of minimum subhalo mass for which
+        diffmahnet is used to generate MAHs, in Msun;
+        for logmsub < logmsub_cutoff, P(θ_MAH | logmsub) = P(θ_MAH | logmsub_cutoff)
+
+    logmsub_cutoff_himass: float
+        base-10 log of maximum subhalo mass for which
+        diffmahnet is used to generate MAHs, in Msun
+
+    subhalo_model_key: str
+        diffmahnet model to use for satellites
+
+    Returns
+    -------
+    subpop: namedtuple
+        subhalo population with fields:
+            nsubhalos: ndarray of shape (n_nub, )
+                subhalo weighted counts
+
+            mah_params_subs: namedtuple of ndarray's with shape (n_subs, n_mah_params)
+                diffmah parameters for each subhalo in the lightcone
+
+            logmu_obs: ndarray of shape (n_subs, )
+                base-10 log of mu=Msub/Mhost for each subhalo in the lightcone
+
+            logmp_obs: ndarray of shape (n_subs, )
+                base-10 log of Mpeak/Msun of each subhalo
+
+            nsub_per_host: int
+                number of subhalo points generated per host halo
+    """
+
+    # number of host halos
+    n_host = cenpop.logmp_obs.size
+
+    # get subhalo weights
+    nsubhalo_weights, lgmu = subhalo_lightcone_weights(
+        cenpop.logmp_obs,
+        lgmsub_min,
+        n_mu_per_host,
+        ccshmf_params,
+    )
+    nsubhalo_weights = nsubhalo_weights.reshape(n_host * n_mu_per_host)
+    lgmu = lgmu.reshape(n_host * n_mu_per_host)
+
+    # get the subhalo mass and time of observation for MAH computations
+    logmsub_obs = lgmu + jnp.repeat(cenpop.logmp_obs, n_mu_per_host)
+    t_obs = jnp.repeat(cenpop.t_obs, n_mu_per_host)
+
+    # get the rescaled mah parameters and mah values at t_obs
+    logmsub_obs_clipped = jnp.clip(logmsub_obs, logmsub_cutoff, logmsub_cutoff_himass)
+    mah_params_subs, logmsub_obs = apply_mah_rescaling(
+        ran_key,
+        logmsub_obs,
+        logmsub_obs_clipped,
+        t_obs,
+        cenpop.logt0,
+        subhalo_model_key,
+    )
+
+    # compute the rescaled mu values at t_obs
+    logmu_obs = logmsub_obs - jnp.repeat(cenpop.logmp_obs, n_mu_per_host)
+
+    # add subhalo weights to the dictionary
+    fields = ("nsubhalos", "mah_params", "logmu_obs", "logmp_obs", "nsub_per_host")
+    data = (nsubhalo_weights, mah_params_subs, logmu_obs, logmsub_obs, n_mu_per_host)
+    subpop = namedtuple("subpop", fields)(*data)
+
+    return subpop

--- a/diffhalos/lightcone_generators/tests/test_mc_lightcone.py
+++ b/diffhalos/lightcone_generators/tests/test_mc_lightcone.py
@@ -1,0 +1,254 @@
+""" """
+
+import numpy as np
+from diffmah.diffmah_kernels import _log_mah_kern
+from jax import numpy as jnp
+from jax import random as jran
+
+from ...ccshmf.ccshmf_model import subhalo_lightcone_weights
+from ...ccshmf.utils import match_cenpop_to_subpop
+from ...mah.diffmahnet.diffmahnet import log_mah_kern
+from ...mah.diffmahnet_utils import mc_mah_cenpop
+from .. import mc_lightcone as mclc
+from .. import mc_lightcone_halos as mclch
+from .. import mc_lightcone_subhalos as mclcsh
+
+
+def test_mc_lc_mf_behaves_as_expected():
+
+    ran_key = jran.key(0)
+
+    lgmp_min = 12.0
+    lgmsub_min = 10.0
+    z_min = 1.2
+    z_max = 1.5
+    sky_area_degsq = 10.0
+
+    z_halopop, logmp_cenpop, mc_lg_mu, subhalo_counts_per_halo = mclc.mc_lc_mf(
+        ran_key,
+        lgmp_min,
+        lgmsub_min,
+        z_min,
+        z_max,
+        sky_area_degsq,
+    )
+
+    assert np.all(np.isfinite(z_halopop))
+    assert np.all(np.isfinite(logmp_cenpop))
+    assert np.all(np.isfinite(mc_lg_mu))
+    assert np.all(np.isfinite(subhalo_counts_per_halo))
+    assert z_halopop.size == logmp_cenpop.size
+    assert mc_lg_mu.size == subhalo_counts_per_halo.sum()
+
+    nsub_tot = int(subhalo_counts_per_halo.sum())
+    lgmhost_pop, host_halo_indx = match_cenpop_to_subpop(
+        logmp_cenpop,
+        subhalo_counts_per_halo,
+        nsub_tot,
+    )
+    assert lgmhost_pop.size == subhalo_counts_per_halo.sum()
+    assert host_halo_indx.size == subhalo_counts_per_halo.sum()
+    assert lgmhost_pop[0] == logmp_cenpop[0]
+    assert lgmhost_pop[-1] == logmp_cenpop[-1]
+    assert host_halo_indx[-1] == logmp_cenpop.size - 1
+
+
+def test_mc_lc_behaves_as_expected():
+    ran_key = jran.key(0)
+
+    lgmp_min = 12.0
+    lgmsub_min = 10.0
+    z_min = 1.2
+    z_max = 1.5
+    sky_area_degsq = 10.0
+
+    halopop = mclc.mc_lc(
+        ran_key,
+        lgmp_min,
+        lgmsub_min,
+        z_min,
+        z_max,
+        sky_area_degsq,
+    )
+
+    for _field in halopop._fields:
+        assert np.all(np.isfinite(halopop._asdict()[_field]))
+
+    n_host = halopop.logmp_obs.size
+    n_subs = halopop.logmu_obs.size
+    for _param in halopop.mah_params._fields:
+        assert halopop.mah_params._asdict()[_param].size == n_host + n_subs
+
+    assert halopop.halo_indx.size == n_host + n_subs
+
+
+def test_weighted_lc_behaves_as_expected():
+    """Check each returned column is finite and has the expected shape"""
+    ran_key = jran.key(0)
+
+    n_host_halos = 100
+    z_min, z_max = 0.1, 3.1
+    sky_area_degsq = 10.0
+    lgmp_min, lgmp_max = 10.0, 15.0
+    args = (ran_key, n_host_halos, z_min, z_max, lgmp_min, lgmp_max, sky_area_degsq)
+    halopop = mclc.weighted_lc(*args)
+
+    n_subs = n_host_halos * halopop.nsub_per_host
+    n_tot = n_host_halos + n_subs
+
+    # Check mah_params for shape and finite
+    assert len(halopop.mah_params) == 5
+    for arr in halopop.mah_params:
+        assert np.all(np.isfinite(arr))
+        assert arr.shape == (n_tot,)
+
+    # Check other columns for shape and finite
+    skip_list = ("logt0", "mah_params", "nsub_per_host")
+    for name, val in zip(halopop._fields, halopop):
+        if name not in skip_list:
+            assert val.shape == (n_tot,), name
+            assert np.all(np.isfinite(val))
+
+    # Check scalar columns for shape and finite
+    assert halopop.logt0.shape == ()
+    assert np.isfinite(halopop.logt0)
+    assert halopop.nsub_per_host.shape == ()
+    assert np.isfinite(halopop.nsub_per_host)
+
+
+def test_weighted_lc_logmp0_is_consistent_with_logmp_obs():
+    """Enforce self-consistent behavior for logmp0 and logmp_obs columns
+    centrals: logmp_obs <= logmp0
+    satellites: logmp_obs == logmp0
+    We perform these checks only for subhalos with t_peak < t_obs
+    """
+    ran_key = jran.key(0)
+
+    n_host_halos = 100
+    z_min, z_max = 0.1, 3.1
+    sky_area_degsq = 10.0
+    lgmp_min, lgmp_max = 10.0, 15.0
+    args = (ran_key, n_host_halos, z_min, z_max, lgmp_min, lgmp_max, sky_area_degsq)
+    halopop = mclc.weighted_lc(*args)
+
+    # centrals: logmp_obs <= logmp0
+    assert np.all(halopop.logmp0[:n_host_halos] >= halopop.logmp_obs[:n_host_halos])
+
+    # satellites: logmp_obs == logmp0
+    _filter_t_peak_t_obs = np.where(
+        halopop.t_obs[n_host_halos:] > halopop.mah_params.t_peak[n_host_halos:]
+    )[0]
+    assert np.allclose(
+        halopop.logmp0[n_host_halos:][_filter_t_peak_t_obs],
+        halopop.logmp_obs[n_host_halos:][_filter_t_peak_t_obs],
+    )
+
+
+def test_weighted_lc_tpeak_subs():
+    """Enforce self-consistent behavior for t_peak and t_obs columns
+    satellites: t_peak <= t_obs
+    for at least some satellites: t_peak != t_obs
+    """
+    ran_key = jran.key(0)
+
+    n_host_halos = 1000
+    z_min, z_max = 0.1, 3.1
+    sky_area_degsq = 10.0
+    lgmp_min, lgmp_max = 10.0, 15.0
+    args = (ran_key, n_host_halos, z_min, z_max, lgmp_min, lgmp_max, sky_area_degsq)
+    halopop = mclc.weighted_lc(*args)
+
+    # satellites: t_peak <= t_obs
+    # ensure that the fraction of subs for which this is false is < 10%
+    _filter_t_peak_t_obs = np.where(
+        halopop.t_obs[n_host_halos:] < halopop.mah_params.t_peak[n_host_halos:]
+    )[0]
+    tol = 0.15
+    assert len(_filter_t_peak_t_obs) / float(halopop.nsub_per_host * n_host_halos) < tol
+
+    # at least SOME satellites should have t_peak != t_obs
+    assert np.any(
+        halopop.mah_params.t_peak[n_host_halos:] != halopop.t_obs[n_host_halos:]
+    )
+
+    # make sure it is the same subhalos that have t_peak>t_obs and logm_obs!=logm0
+    _filter_m_obs_m0 = np.where(
+        halopop.logmp0[n_host_halos:] != halopop.logmp_obs[n_host_halos:]
+    )[0]
+    assert np.all(_filter_m_obs_m0 == _filter_t_peak_t_obs)
+
+
+def test_weighted_lc_tpeak_clip():
+    """Enforce self-consistent behavior for t_peak and t_obs columns
+    satellites: t_peak <= t_obs
+    by clipping t_peak at t_obs in the diffmahnet parameters
+    """
+    ran_key = jran.key(0)
+    cen_key, sub_key = jran.split(ran_key, 2)
+
+    n_host = 100
+    z_obs = np.linspace(0.2, 1.5, n_host)
+    logmp_obs = np.linspace(11.0, 14.0, n_host)
+
+    lgmsub_min = 10.0
+    sky_area_degsq = 10.0
+
+    cenpop = mclch._weighted_lc_halos_from_grid(
+        cen_key,
+        z_obs,
+        logmp_obs,
+        sky_area_degsq,
+    )
+
+    # number of host halos
+    n_host = cenpop.logmp_obs.size
+
+    # get mu values
+    lgmu = subhalo_lightcone_weights(
+        cenpop.logmp_obs,
+        lgmsub_min,
+        mclcsh.N_LGMU_PER_HOST,
+        mclcsh.DEFAULT_CCSHMF_PARAMS,
+    )[1].reshape(n_host * mclcsh.N_LGMU_PER_HOST)
+
+    # get the subhalo mass and time of observation for MAH computations
+    logmsub_obs = lgmu + jnp.repeat(cenpop.logmp_obs, mclcsh.N_LGMU_PER_HOST)
+    t_obs = jnp.repeat(cenpop.t_obs, mclcsh.N_LGMU_PER_HOST)
+
+    # get the rescaled mah parameters and mah values at t_obs
+    logmsub_obs_clipped = jnp.clip(
+        logmsub_obs, mclcsh.DEFAULT_LOGMSUB_CUTOFF, mclcsh.DEFAULT_LOGMSUB_HIMASS_CUTOFF
+    )
+    mah_params_uncorrected = mc_mah_cenpop(
+        logmsub_obs_clipped,
+        t_obs,
+        sub_key,
+        mclcsh.DEFAULT_DIFFMAHNET_SAT_MODEL,
+    )
+
+    # clip t_peak values for subs's mah parameters
+    t_peak_clip = jnp.clip(mah_params_uncorrected.t_peak, 0.0, t_obs)
+    mah_params_uncorrected = mah_params_uncorrected._replace(t_peak=t_peak_clip)
+
+    # compute the uncorrected observed masses
+    logmp_obs_uncorrected = log_mah_kern(mah_params_uncorrected, t_obs, cenpop.logt0)
+
+    # rescale the mah parameters to the correct logm0
+    delta_logm_obs = logmp_obs_uncorrected - logmsub_obs
+    logm0_rescaled = mah_params_uncorrected.logm0 - delta_logm_obs
+    mah_params_subs = mah_params_uncorrected._replace(logm0=logm0_rescaled)
+
+    # compute observed mass with corrected parameters
+    logmsub_obs = log_mah_kern(mah_params_subs, t_obs, cenpop.logt0)
+
+    # compute mass of subs at z=0
+    logmp0_subs = _log_mah_kern(mah_params_subs, 10**cenpop.logt0, cenpop.logt0)
+
+    # satellites: t_peak <= t_obs
+    assert np.all(mah_params_subs.t_peak <= t_obs)
+
+    # at least SOME satellites should have t_peak != t_obs
+    assert np.any(mah_params_subs.t_peak != t_obs)
+
+    # satellites: logmp_obs == logmp0
+    assert np.allclose(logmp0_subs, logmsub_obs)

--- a/diffhalos/lightcone_generators/tests/test_mc_lightcone_halos.py
+++ b/diffhalos/lightcone_generators/tests/test_mc_lightcone_halos.py
@@ -1,0 +1,324 @@
+""" """
+
+import numpy as np
+from jax import numpy as jnp
+from jax import random as jran
+
+from ...calibrations.hmf_cal import hacc_core_hmf_params as hchmf
+from ...cosmology import DEFAULT_COSMOLOGY, flat_wcdm
+from ...hmf import hmf_model, mc_hosts
+from ...mah.diffmahnet.diffmahnet import log_mah_kern
+from ...mah.utils import apply_mah_rescaling
+from ...utils.stratified_grid import redshift_mass_grid
+from .. import mc_lightcone_halos as mclh
+
+
+def test_mc_lightcone_host_halo_mass_function():
+    """
+    Enforce mc_lightcone_host_halo_mass_function
+    produces halo mass functions that are consistent
+    diffsky.mass_functions.mc_hosts evaluated at the median redshift
+    """
+    lgmp_min = 12.0
+    lgmp_max = 17.0
+    z_min, z_max = 0.4, 0.5
+    sky_area_degsq = 10.0
+
+    cosmo = DEFAULT_COSMOLOGY
+
+    n_tests = 5
+    ran_keys = jran.split(jran.key(0), n_tests)
+    for ran_key in ran_keys:
+        args = (ran_key, lgmp_min, z_min, z_max, sky_area_degsq)
+        redshifts_galpop, logmp_halopop = mclh.mc_lc_hmf(*args, lgmp_max=lgmp_max)
+
+        assert np.all(np.isfinite(redshifts_galpop))
+        assert np.all(np.isfinite(logmp_halopop))
+        assert logmp_halopop.shape == redshifts_galpop.shape
+        assert np.all(redshifts_galpop >= z_min)
+        assert np.all(redshifts_galpop <= z_max)
+        assert np.all(logmp_halopop > lgmp_min)
+
+        z_med = np.median(redshifts_galpop)
+
+        vol_lo = (
+            (4 / 3)
+            * np.pi
+            * flat_wcdm.comoving_distance_to_z(
+                z_min,
+                *cosmo,
+            )
+            ** 3
+        )
+        vol_hi = (
+            (4 / 3)
+            * np.pi
+            * flat_wcdm.comoving_distance_to_z(
+                z_max,
+                *cosmo,
+            )
+            ** 3
+        )
+        fsky = sky_area_degsq / hmf_model.FULL_SKY_AREA
+        vol_com_mpc = fsky * (vol_hi - vol_lo)
+
+        lgmp_halopop_zmed = mc_hosts.mc_host_halos_singlez(
+            ran_key,
+            lgmp_min,
+            z_med,
+            vol_com_mpc,
+            lgmp_max=lgmp_max,
+        )
+
+        n_lightcone, n_snapshot = redshifts_galpop.size, lgmp_halopop_zmed.size
+        fracdiff = (n_lightcone - n_snapshot) / n_snapshot
+        assert np.abs(fracdiff) < 0.05
+
+        lgmp_hist_lc, lgmp_bins = np.histogram(logmp_halopop, bins=100)
+        lgmp_hist_zmed, _ = np.histogram(lgmp_halopop_zmed, bins=lgmp_bins)
+        msk_counts = lgmp_hist_zmed > 500
+        fracdiff = (
+            lgmp_hist_lc[msk_counts] - lgmp_hist_zmed[msk_counts]
+        ) / lgmp_hist_zmed[msk_counts]
+        assert np.all(np.abs(fracdiff) < 0.1)
+
+
+def test_mc_lightcone_host_halo_mass_function_lgmp_max_feature():
+    """
+    Using lgmp_max gives the same halo counts
+    as when not using it and masking
+    """
+
+    ran_key = jran.key(0)
+    lgmp_min = 12.0
+    z_min, z_max = 0.4, 0.5
+    sky_area_degsq = 200.0
+    lgmp_max_test = 13.0
+
+    n_tests = 10
+    for __ in range(n_tests):
+        ran_key, test_key = jran.split(ran_key, 2)
+
+        args = (test_key, lgmp_min, z_min, z_max, sky_area_degsq)
+        z_halopop, logmp_halopop = mclh.mc_lc_hmf(*args)
+
+        z_halopop2, logmp_halopop2 = mclh.mc_lc_hmf(*args, lgmp_max=lgmp_max_test)
+        assert z_halopop.size > z_halopop2.size
+        assert z_halopop2.size == logmp_halopop2.size
+
+        n1 = np.sum(logmp_halopop < lgmp_max_test)
+        n2 = logmp_halopop2.size
+        assert np.allclose(n1, n2, rtol=0.02)
+
+
+def test_mc_lightcone_host_halo():
+    """
+    Enforce mc_lightcone_host_halo returns reasonable results
+    """
+
+    ran_key = jran.key(0)
+    lgmp_min = 12.0
+    sky_area_degsq = 1.0
+
+    n_tests = 5
+    z_max_arr = np.linspace(0.2, 2.5, n_tests)
+    for z_max in z_max_arr:
+        test_key, ran_key = jran.split(ran_key, 2)
+        z_min = z_max - 0.05
+
+        args = (test_key, lgmp_min, z_min, z_max, sky_area_degsq)
+        cenpop = mclh.mc_lc_halos(*args)
+
+        for _field in cenpop._fields:
+            assert np.all(np.isfinite(cenpop._asdict()[_field]))
+
+        assert cenpop.logmp_obs.size == cenpop.logmp0.size == cenpop.z_obs.size
+
+        assert np.all(cenpop.z_obs >= z_min)
+        assert np.all(cenpop.z_obs <= z_max)
+
+        # some halos with logmp_obs<lgmp_min is ok,
+        # but too many indicates an issue with diffmahnet replicating logmp_obs
+        assert np.mean(cenpop.logmp_obs < lgmp_min) < 0.2, f"z_min={z_min:.2f}"
+
+
+def test_mc_lightcone_host_halo_alt_mf_params():
+    """
+    Enforce mc_lightcone_host_halo returns
+    reasonable results when passed
+    alternative halo mass function parameters
+    """
+    ran_key = jran.key(0)
+    lgmp_min = 12.0
+    sky_area_degsq = 1.0
+
+    n_tests = 5
+    z_max_arr = np.linspace(0.2, 2.5, n_tests)
+    for z_max in z_max_arr:
+        test_key, ran_key = jran.split(ran_key, 2)
+        z_min = z_max - 0.05
+
+        args = (test_key, lgmp_min, z_min, z_max, sky_area_degsq)
+        cenpop = mclh.mc_lc_halos(*args, hmf_params=hchmf.HMF_PARAMS)
+
+        for _field in cenpop._fields:
+            assert np.all(np.isfinite(cenpop._asdict()[_field]))
+
+        assert cenpop.logmp_obs.size == cenpop.logmp0.size == cenpop.z_obs.size
+
+        assert np.all(cenpop.z_obs >= z_min)
+        assert np.all(cenpop.z_obs <= z_max)
+
+        # Some halos with logmp_obs<lgmp_min is ok,
+        # but too many indicates an issue with diffmahnet replicating logmp_obs
+        assert np.mean(cenpop.logmp_obs < lgmp_min) < 0.2, f"z_min={z_min:.2f}"
+
+
+def test_mah_params_rescaling():
+    """Assert that the rescaled MAH parameters produce
+    masses that are close to the expected ones"""
+
+    ran_key = jran.key(0)
+    halopop_key, mah_key = jran.split(ran_key, 2)
+
+    lgmp_min = 12.0
+    z_min, z_max = 0.4, 0.5
+    sky_area_degsq = 200.0
+    logmp_cutoff = mclh.DEFAULT_LOGMP_CUTOFF
+    logmp_cutoff_himass = mclh.DEFAULT_LOGMP_HIMASS_CUTOFF
+    cosmo_params = DEFAULT_COSMOLOGY
+    centrals_model_key = mclh.DEFAULT_DIFFMAHNET_CEN_MODEL
+
+    args = (halopop_key, lgmp_min, z_min, z_max, sky_area_degsq)
+    z_obs, logmp_obs_mf = mclh.mc_lc_hmf(*args)
+
+    t_obs = flat_wcdm.age_at_z(z_obs, *cosmo_params)
+    t_0 = flat_wcdm.age_at_z0(*cosmo_params)
+    logt0 = jnp.log10(t_0)
+
+    # get the rescaled MAH parameters and MAH's for all halos
+    logmp_obs_clipped = jnp.clip(logmp_obs_mf, logmp_cutoff, logmp_cutoff_himass)
+    mah_params, logmp_obs = apply_mah_rescaling(
+        mah_key,
+        logmp_obs_mf,
+        logmp_obs_clipped,
+        t_obs,
+        logt0,
+        centrals_model_key,
+    )
+
+    # compute observed mass with corrected parameters
+    logmp_obs = log_mah_kern(mah_params, t_obs, logt0)
+
+    assert np.allclose(logmp_obs, logmp_obs_mf, rtol=1e-5)
+
+
+def test_mc_weighted_halo_lightcone_stratified():
+    ran_key = jran.key(0)
+    n_tests = 10
+
+    sky_area_degsq = 15.0
+
+    n_per_dim = 10
+    num_halos = n_per_dim**2
+
+    for itest in range(n_tests):
+        ran_key, test_key = jran.split(ran_key, 2)
+
+        lgm_key, z_key, lc_key = jran.split(test_key, 3)
+        lgmp_min = jran.uniform(lgm_key, minval=11, maxval=12, shape=())
+        lgmp_max = jran.uniform(lgm_key, minval=13, maxval=14, shape=())
+        z_min = jran.uniform(z_key, minval=0.1, maxval=1.0, shape=())
+        z_max = z_min + 1
+
+        z_obs, logmp_obs = redshift_mass_grid(
+            n_per_dim,
+            test_key,
+            z_min,
+            z_max,
+            lgmp_min,
+            lgmp_max,
+        )
+
+        cenpop = mclh._weighted_lc_halos_from_grid(
+            ran_key,
+            z_obs,
+            logmp_obs,
+            sky_area_degsq,
+        )
+
+        assert np.all(np.isfinite(cenpop.nhalos))
+        assert cenpop.logmp_obs.size == num_halos
+
+        assert np.all(cenpop.z_obs >= z_min)
+        assert np.all(cenpop.z_obs <= z_max)
+
+        # some halos with logmp_obs<lgmp_min or logmp_obs>lgmp_max is ok,
+        # but too many indicates an issue with diffmahnet replicating logmp_obs
+        assert np.mean(cenpop.logmp_obs < lgmp_min) < 0.2
+        assert np.mean(cenpop.logmp_obs > lgmp_max) < 0.2
+
+
+def test_mc_weighted_halo_lightcone_input_grid():
+    ran_key = jran.key(0)
+    n_tests = 10
+
+    sky_area_degsq = 15.0
+
+    num_halos = 1_000
+    for itest in range(n_tests):
+        ran_key, test_key = jran.split(ran_key, 2)
+
+        lgm_key, z_key, lc_key = jran.split(test_key, 3)
+        lgmp_min = jran.uniform(lgm_key, minval=11, maxval=12, shape=())
+        lgmp_max = jran.uniform(lgm_key, minval=13, maxval=14, shape=())
+        z_min = jran.uniform(z_key, minval=0.1, maxval=1.0, shape=())
+        z_max = z_min + 1
+
+        z_grid = np.linspace(z_min, z_max, num_halos)
+        lgmp_grid = np.linspace(lgmp_min, lgmp_max, num_halos)
+
+        cenpop = mclh._weighted_lc_halos_from_grid(
+            ran_key,
+            z_grid,
+            lgmp_grid,
+            sky_area_degsq,
+        )
+
+        assert np.all(np.isfinite(cenpop.nhalos))
+        assert cenpop.logmp_obs.size == num_halos
+
+        assert np.all(cenpop.z_obs >= z_min)
+        assert np.all(cenpop.z_obs <= z_max)
+
+        # some halos with logmp_obs<lgmp_min or logmp_obs>lgmp_max is ok,
+        # but too many indicates an issue with diffmahnet replicating logmp_obs
+        assert np.mean(cenpop.logmp_obs < lgmp_min) < 0.2
+        assert np.mean(cenpop.logmp_obs > lgmp_max) < 0.2
+
+
+def test_weighted_lc_halos():
+    ran_key = jran.key(0)
+    n_halos = 50
+    z_min, z_max = 0.4, 2.5
+    lgmp_min, lgmp_max = 10.0, 15.5
+    sky_area_degsq = 15.0
+    cenpop = mclh.weighted_lc_halos(
+        ran_key, n_halos, z_min, z_max, lgmp_min, lgmp_max, sky_area_degsq
+    )
+    for field in mclh.CenPop._fields:
+        assert hasattr(cenpop, field)
+
+    assert np.all(np.isfinite(cenpop.nhalos))
+    assert cenpop.logmp_obs.size == n_halos
+
+    assert np.all(cenpop.z_obs >= z_min)
+    assert np.all(cenpop.z_obs <= z_max)
+
+    # some halos with logmp_obs<lgmp_min or logmp_obs>lgmp_max is ok,
+    # but too many indicates an issue with diffmahnet replicating logmp_obs
+    assert np.mean(cenpop.logmp_obs < lgmp_min) < 0.002
+    assert np.mean(cenpop.logmp_obs > lgmp_max) < 0.002
+
+    assert np.all(cenpop.logmp_obs > lgmp_min)
+    assert np.all(cenpop.logmp_obs < lgmp_max)

--- a/diffhalos/lightcone_generators/tests/test_mc_lightcone_subhalos.py
+++ b/diffhalos/lightcone_generators/tests/test_mc_lightcone_subhalos.py
@@ -1,0 +1,291 @@
+""" """
+
+import numpy as np
+from jax import numpy as jnp
+from jax import random as jran
+
+from ...ccshmf import mc_subs
+from ...ccshmf.utils import match_cenpop_to_subpop
+from ...mah.utils import apply_mah_rescaling
+from .. import mc_lightcone_subhalos as mclsh
+from ..utils import generate_mock_cenpop
+
+
+def test_mc_lc_shmf_works_as_expected():
+    ran_key = jran.key(0)
+
+    n_tests = 5
+
+    nhost = 100
+    lgmhost = np.linspace(13.0, 15.0, nhost)
+    lgmp_min = 12.0
+
+    test_keys = jran.split(ran_key, n_tests)
+    for test_key in test_keys:
+        mc_lg_mu, subs_per_halo = mclsh.mc_lc_shmf(
+            test_key,
+            lgmhost,
+            lgmp_min,
+        )
+
+        nsub_tot = int(subs_per_halo.sum())
+        lgmhost_pop, host_halo_indx = match_cenpop_to_subpop(
+            lgmhost,
+            subs_per_halo,
+            nsub_tot,
+        )
+
+        assert mc_lg_mu.size == lgmhost_pop.size == host_halo_indx.size
+        assert np.all(np.isfinite(mc_lg_mu))
+        assert np.all(np.isfinite(lgmhost_pop))
+        assert np.all(np.isfinite(host_halo_indx))
+        assert np.all(np.isfinite(subs_per_halo))
+        assert subs_per_halo.sum() == mc_lg_mu.size
+
+
+def test_mc_lc_shmf_lgmp_min_parameter_behavior():
+    ran_key = jran.key(0)
+
+    n_tests = 5
+    lgmp_mins = np.linspace(9.0, 11.0, n_tests)
+
+    nhost = 100
+    lgmhost = np.linspace(11.5, 14.0, nhost)
+
+    for lgmp_min in lgmp_mins:
+        mc_lg_mu, subs_per_halo = mclsh.mc_lc_shmf(
+            ran_key,
+            lgmhost,
+            lgmp_min,
+        )
+
+        nsub_tot = int(subs_per_halo.sum())
+        lgmhost_pop, host_halo_indx = match_cenpop_to_subpop(
+            lgmhost,
+            subs_per_halo,
+            nsub_tot,
+        )
+
+        assert mc_lg_mu.size == lgmhost_pop.size == host_halo_indx.size
+        assert np.all(np.isfinite(mc_lg_mu))
+        assert np.all(np.isfinite(lgmhost_pop))
+        assert np.all(np.isfinite(host_halo_indx))
+        assert np.all(np.isfinite(subs_per_halo))
+        assert subs_per_halo.sum() == mc_lg_mu.size
+
+
+def test_mc_lc_subhalos_works_as_expected():
+
+    ran_key = jran.key(0)
+
+    z_min = 0.2
+    z_max = 2.0
+    logmp_min = 11.0
+    logmp_max = 14.0
+    lgmp_min = 10.0
+    n_cens = 1_000
+
+    # use a mock host halo population for this test
+    cenpop = generate_mock_cenpop(z_min, z_max, logmp_min, logmp_max, n_cens=n_cens)
+
+    # generate a subhalo population
+    subpop = mclsh.mc_lc_subhalos(ran_key, cenpop, lgmp_min)
+
+    for _field in subpop._fields:
+        assert np.all(np.isfinite(subpop._asdict()[_field]))
+
+    for _field in subpop.mah_params._fields:
+        assert subpop.mah_params._asdict()[_field].shape[0] == subpop.logmu_obs.size
+
+
+def test_mc_lc_subhalos_vs_subpop_from_mc_subs():
+
+    ran_key = jran.key(0)
+
+    z_min = 0.4
+    z_max = 0.5
+    logmp_min = 11.0
+    logmp_max = 14.0
+    lgmp_min = 10.0
+    n_cens = 2_000
+
+    # use a mock host halo population for this test
+    cenpop = generate_mock_cenpop(z_min, z_max, logmp_min, logmp_max, n_cens=n_cens)
+
+    n_tests = 5
+    test_keys = jran.split(ran_key, n_tests)
+    for test_key in test_keys:
+        lc_subpop = mclsh.mc_lc_subhalos(test_key, cenpop, lgmp_min)
+        mc_lg_mu_pop = mc_subs.generate_subhalopop(
+            test_key,
+            cenpop.logmp_obs,
+            lgmp_min,
+        )[0]
+
+        lg_mu_lc, lg_mu_bins = np.histogram(lc_subpop.logmu_obs, bins=100)
+        lg_mu_pop, _ = np.histogram(mc_lg_mu_pop, bins=lg_mu_bins)
+        msk_counts = lg_mu_pop > 500
+
+        fracdiff = (lg_mu_lc[msk_counts] - lg_mu_pop[msk_counts]) / lg_mu_pop[
+            msk_counts
+        ]
+        assert np.all(np.abs(fracdiff) < 0.2)
+
+        del lc_subpop, mc_lg_mu_pop
+
+
+def test_mah_params_rescaling():
+    """Assert that the rescaled MAH parameters produce
+    masses that are close to the expected ones"""
+
+    ran_key = jran.key(0)
+    satpop_key, mah_key = jran.split(ran_key, 2)
+
+    z_min = 0.4
+    z_max = 0.5
+    logmp_min = 11.0
+    logmp_max = 14.0
+    lgmp_min = 10.0
+    n_cens = 2_000
+
+    subhalo_model_key = mclsh.DEFAULT_DIFFMAHNET_SAT_MODEL
+
+    # use a mock host halo population for this test
+    cenpop = generate_mock_cenpop(z_min, z_max, logmp_min, logmp_max, n_cens=n_cens)
+
+    mc_lg_mu_shmf, n_mu_per_host = mc_subs.generate_subhalopop(
+        satpop_key,
+        cenpop.logmp_obs,
+        lgmp_min,
+    )
+
+    logmsub_obs_shmf = mc_lg_mu_shmf + jnp.repeat(cenpop.logmp_obs, n_mu_per_host)
+    t_obs = jnp.repeat(cenpop.t_obs, n_mu_per_host)
+
+    # get the rescaled MAH parameters and MAH's for all halos
+    logmp_obs_clipped = jnp.clip(
+        logmsub_obs_shmf,
+        mclsh.DEFAULT_LOGMSUB_CUTOFF,
+        mclsh.DEFAULT_LOGMSUB_HIMASS_CUTOFF,
+    )
+    mah_params, logmsub_obs_rescaled = apply_mah_rescaling(
+        mah_key,
+        logmsub_obs_shmf,
+        logmp_obs_clipped,
+        t_obs,
+        cenpop.logt0,
+        subhalo_model_key,
+    )
+    mc_lg_mu_rescaled = logmsub_obs_rescaled - jnp.repeat(
+        cenpop.logmp_obs, n_mu_per_host
+    )
+
+    assert np.allclose(logmsub_obs_rescaled, logmsub_obs_shmf, rtol=1e-5)
+    assert np.allclose(mc_lg_mu_rescaled, mc_lg_mu_shmf, rtol=1e-5)
+
+
+def test_mc_weighted_lc_subhalos_behaves_as_expected():
+    ran_key = jran.key(0)
+
+    z_min = 0.4
+    z_max = 0.5
+    logmp_min = 11.0
+    logmp_max = 14.0
+    lgmp_min = 10.0
+    n_cens = 2_000
+
+    n_sub_per_host = mclsh.N_LGMU_PER_HOST
+
+    # use a mock host halo population for this test
+    cenpop = generate_mock_cenpop(z_min, z_max, logmp_min, logmp_max, n_cens=n_cens)
+    subpop = mclsh.weighted_lc_subhalos(ran_key, cenpop, lgmp_min)
+
+    for _field in subpop._fields:
+        assert np.all(np.isfinite(subpop._asdict()[_field]))
+
+    assert subpop.nsubhalos.shape == (n_cens * n_sub_per_host,)
+    assert subpop.logmu_obs.shape == (n_cens * n_sub_per_host,)
+
+    nsub_tot = int(subpop.nsub_per_host * n_cens)
+    _, host_index_for_subs = match_cenpop_to_subpop(
+        cenpop.logmp_obs,
+        subpop.nsub_per_host,
+        nsub_tot,
+    )
+
+    assert host_index_for_subs.shape == (n_cens * n_sub_per_host,)
+    assert host_index_for_subs.dtype == np.int64
+    assert host_index_for_subs[0] == 0
+    assert host_index_for_subs[-1] == n_cens - 1
+    for arr in subpop.mah_params:
+        assert arr.size == n_cens * n_sub_per_host
+
+
+def test_mc_weighted_lc_subhalos_with_different_nsubs_per_host():
+    ran_key = jran.key(0)
+
+    z_min = 0.4
+    z_max = 0.5
+    logmp_min = 11.0
+    logmp_max = 14.0
+    lgmp_min = 10.0
+    n_cens = 2_000
+
+    n_sub_per_host = mclsh.N_LGMU_PER_HOST + 2
+
+    # use a mock host halo population for this test
+    cenpop = generate_mock_cenpop(z_min, z_max, logmp_min, logmp_max, n_cens=n_cens)
+    subpop = mclsh.weighted_lc_subhalos(
+        ran_key, cenpop, lgmp_min, n_mu_per_host=n_sub_per_host
+    )
+
+    for _field in subpop._fields:
+        assert np.all(np.isfinite(subpop._asdict()[_field]))
+
+    assert subpop.nsubhalos.shape == (n_cens * n_sub_per_host,)
+    assert subpop.logmu_obs.shape == (n_cens * n_sub_per_host,)
+
+    nsub_tot = int(subpop.nsub_per_host * n_cens)
+    _, host_index_for_subs = match_cenpop_to_subpop(
+        cenpop.logmp_obs,
+        subpop.nsub_per_host,
+        nsub_tot,
+    )
+
+    assert host_index_for_subs.shape == (n_cens * n_sub_per_host,)
+    assert host_index_for_subs.dtype == np.int64
+    assert host_index_for_subs[0] == 0
+    assert host_index_for_subs[-1] == n_cens - 1
+    for _key in subpop.mah_params._fields:
+        assert subpop.mah_params._asdict()[_key].size == n_cens * n_sub_per_host
+
+
+def test_mc_weighted_lc_subhalos_agrees_with_mc_subhalopop():
+
+    ran_key = jran.key(0)
+
+    z_min = 0.4
+    z_max = 0.5
+    logmp_min = 11.0
+    logmp_max = 14.0
+    n_cens = 2_000
+
+    # use a mock host halo population for this test
+    cenpop = generate_mock_cenpop(z_min, z_max, logmp_min, logmp_max, n_cens=n_cens)
+
+    n_tests = 5
+    lgmp_min_arr = np.linspace(9.0, 10.0, n_tests)
+    for lgmp_min in lgmp_min_arr:
+        halopop = mclsh.weighted_lc_subhalos(ran_key, cenpop, lgmp_min)
+
+        mc_lg_mu_pop = mc_subs.generate_subhalopop(
+            ran_key,
+            cenpop.logmp_obs,
+            lgmp_min,
+        )[0]
+
+        assert np.allclose(
+            mc_lg_mu_pop.size,
+            halopop.nsubhalos.sum(),
+            rtol=0.1,
+        )

--- a/diffhalos/lightcone_generators/tests/test_utils.py
+++ b/diffhalos/lightcone_generators/tests/test_utils.py
@@ -1,0 +1,32 @@
+""" """
+
+import numpy as np
+
+from ..utils import generate_mock_cenpop
+
+
+def test_generate_mock_cenpop_behaves_as_expected():
+
+    z_min = 0.2
+    z_max = 2.0
+    logmp_min = 11.0
+    logmp_max = 14.0
+    n_cens = 100
+
+    cenpop = generate_mock_cenpop(
+        z_min,
+        z_max,
+        logmp_min,
+        logmp_max,
+        n_cens=n_cens,
+    )
+
+    assert "t_obs" in cenpop._fields
+    assert "logmp_obs" in cenpop._fields
+    assert "logt0" in cenpop._fields
+
+    assert np.all(np.isfinite(cenpop.t_obs))
+    assert np.all(np.isfinite(cenpop.logmp_obs))
+    assert np.isfinite(cenpop.logt0)
+    assert np.all(cenpop.t_obs <= 10**cenpop.logt0)
+    assert np.all((cenpop.logmp_obs >= logmp_min) * (cenpop.logmp_obs <= logmp_max))

--- a/diffhalos/lightcone_generators/utils.py
+++ b/diffhalos/lightcone_generators/utils.py
@@ -1,0 +1,74 @@
+"""Useful utilities to be used with the lightcone module"""
+
+from collections import namedtuple
+from functools import partial
+
+from jax import jit as jjit
+from jax import numpy as jnp
+
+from ..cosmology import DEFAULT_COSMOLOGY
+from ..cosmology.cosmo_basics import get_tobs_from_zobs
+
+__all__ = ("generate_mock_cenpop",)
+
+
+@partial(jjit, static_argnames=["n_cens"])
+def generate_mock_cenpop(
+    z_min,
+    z_max,
+    logmp_min,
+    logmp_max,
+    cosmo_params=DEFAULT_COSMOLOGY,
+    n_cens=200,
+):
+    """
+    Convenience function to easily get a mock central
+    halo population between two redshifts and masses,
+    on a regular grid
+
+    Parameters
+    ----------
+    z_min: float
+        minumum redshift
+
+    z_max: float
+        maximum redshift
+
+    logmp_min: float
+        minumum halo mass, in Msun
+
+    logmp_max: float
+        minumum halo mass, in Msun
+
+    cosmo_params: namedtuple
+        dsps.cosmology.flat_wcdm cosmology
+        cosmo_params = (Om0, w0, wa, h)
+
+    n_cens: int
+        number of generated halos
+
+    Returns
+    -------
+    cenpop: namedtuple
+        central halo population with fields
+            logmp_obs: ndarray of shape (n_host, )
+                base-10 log of halo mass at observation, in Msun
+
+            t_obs: ndarray of shape (n_host, )
+                cosmic time at observation, in Gyr
+
+            logt0: float
+                base-10 log of cosmic time at today, in Gyr
+    """
+    z_obs = jnp.linspace(z_min, z_max, n_cens)
+    logmp_obs = jnp.linspace(logmp_min, logmp_max, n_cens)
+
+    t_obs, t_0 = get_tobs_from_zobs(z_obs, cosmo_params=cosmo_params)
+    logt0 = jnp.log10(t_0)
+
+    fields = ("logmp_obs", "t_obs", "logt0")
+    values = (logmp_obs, t_obs, logt0)
+
+    cenpop = namedtuple("cenpop", fields)(*values)
+
+    return cenpop

--- a/diffhalos/mah/diffmahnet/__init__.py
+++ b/diffhalos/mah/diffmahnet/__init__.py
@@ -1,4 +1,8 @@
 from .diffmahnet import (  # noqa: F401
-    DiffMahFlow, Scaler, gen_time_grids, log_mah_kern,
-    pretrained_model_names, load_pretrained_model,
+    DiffMahFlow,
+    Scaler,
+    gen_time_grids,
+    log_mah_kern,
+    pretrained_model_names,
+    load_pretrained_model,
 )

--- a/diffhalos/mah/diffmahnet/tests/test_diffmahflow.py
+++ b/diffhalos/mah/diffmahnet/tests/test_diffmahflow.py
@@ -13,8 +13,7 @@ def test_diffmahflow():
     # m_obs and t_obs
     fake_conditions = jax.random.normal(keys[0], (ndata, 2)) + 1.5
     fake_mah_uparams = jax.random.normal(keys[1], (ndata, 5)) * 0.2 - 4.0
-    scaler = diffmahnet.Scaler.compute(
-        fake_mah_uparams, fake_conditions)
+    scaler = diffmahnet.Scaler.compute(fake_mah_uparams, fake_conditions)
 
     flow = diffmahnet.DiffMahFlow(scaler)
     test_prediction = flow.sample(fake_conditions, keys[2])
@@ -29,6 +28,5 @@ def test_diffmahflow():
     ), "Std of predictions should be close to the std of fake data"
 
     # Make sure asparams=True gives tuple output
-    mahparams_prediction = flow.sample(
-        fake_conditions, keys[2], asparams=True)
+    mahparams_prediction = flow.sample(fake_conditions, keys[2], asparams=True)
     assert isinstance(mahparams_prediction, tuple)

--- a/diffhalos/mah/utils.py
+++ b/diffhalos/mah/utils.py
@@ -45,21 +45,20 @@ def rescale_mah_parameters(
     return mah_params
 
 
-@partial(jjit, static_argnames=["centrals_model_key"])
+@partial(jjit, static_argnames=["mah_model_key"])
 def apply_mah_rescaling(
     mah_key,
     logmp_obs_mf,
     logmp_obs_clipped,
     t_obs,
     logt0,
-    centrals_model_key,
+    mah_model_key,
 ):
-
     mah_params_uncorrected = mc_mah_cenpop(
         logmp_obs_clipped,
         t_obs,
         mah_key,
-        centrals_model_key,
+        mah_model_key,
     )
 
     # compute the uncorrected observed masses

--- a/diffhalos/tests/test_imports.py
+++ b/diffhalos/tests/test_imports.py
@@ -5,3 +5,4 @@ def test_top_level_imports():
     """Enforce all key user-facing functions are importable directly from diffhalos"""
     from .. import redshift_mass_grid  # noqa
     from .. import weighted_lc  # noqa
+    from .. import weighted_lc_halos  # noqa

--- a/docs/source/diffhalos_quickstart.ipynb
+++ b/docs/source/diffhalos_quickstart.ipynb
@@ -9,6 +9,27 @@
     "\n",
     "This quickstart guide gives an overview of the core features of Diffhalos, and demonstrates how to use the primary functions of the library."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4581335b-aaaa-4d62-8292-60e4a76945bd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from diffhalos.lightcone import weighted_lc\n",
+    "from jax import random as jran\n",
+    "\n",
+    "ran_key = jran.key(0)\n",
+    "\n",
+    "n_host_halos = 200\n",
+    "z_min, z_max = 0.4, 2.5\n",
+    "lgmp_min, lgmp_max = 10.5, 15.5\n",
+    "sky_area_degsq = 500.0\n",
+    "args = (ran_key, n_host_halos, z_min, z_max, lgmp_min, lgmp_max, sky_area_degsq)\n",
+    "halopop = weighted_lc(*args)\n",
+    "print(halopop._fields)"
+   ]
   }
  ],
  "metadata": {

--- a/docs/source/diffhalos_quickstart.ipynb
+++ b/docs/source/diffhalos_quickstart.ipynb
@@ -7,7 +7,10 @@
    "source": [
     "# Quickstart\n",
     "\n",
-    "This quickstart guide gives an overview of the core features of Diffhalos, and demonstrates how to use the primary functions of the library."
+    "This quickstart guide gives an overview of the core features of Diffhalos,\n",
+    "and demonstrates how to use the primary functions of the library.\n",
+    "\n",
+    "The cell below shows how to generate a lightcone of halos and subhalos, and their mass assembly histories."
    ]
   },
   {
@@ -17,18 +20,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from diffhalos.lightcone import weighted_lc\n",
-    "from jax import random as jran\n",
+    "from diffhalos import weighted_lc\n",
     "\n",
+    "from jax import random as jran\n",
     "ran_key = jran.key(0)\n",
     "\n",
     "n_host_halos = 200\n",
     "z_min, z_max = 0.4, 2.5\n",
     "lgmp_min, lgmp_max = 10.5, 15.5\n",
     "sky_area_degsq = 500.0\n",
+    "\n",
     "args = (ran_key, n_host_halos, z_min, z_max, lgmp_min, lgmp_max, sky_area_degsq)\n",
     "halopop = weighted_lc(*args)\n",
     "print(halopop._fields)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d24ad2fe-b244-4c8b-8ec6-bbc198c5760d",
+   "metadata": {},
+   "source": [
+    "### mass-function weighting\n",
+    "\n",
+    "Every halo and subhalo in the returned lightcone has a _weight_ that encodes the multiplicity of the halo. For any input choice of the number of returned halos, the weights are determined according to the halo and subhalo mass functions..."
    ]
   }
  ],


### PR DESCRIPTION
This PR is WIP and not intended to merge. There is a failing test `test_weighted_lc_logmp0_is_consistent_with_logmp_obs` that I am not sure about, so tagging @georgezch to see if he understands what is going on.

There are several changes going on at once here, and I will summarize in a future PR that brings in unbroken code, but for present purposes, here is a summary of the relevant changes and what I'm trying to understand. In this revised version of the `weighted_lc` function:
1. All returned arrays have the same shape, `(n_hosts + n_subs, )`, so I am doing a bunch of additional concatenation.
2. In particular, we now return `logmp0` and `logmp_obs`, each with shape `(n_hosts + n_subs, )`.
3. For `logmp_obs`, the`cenpop` quantity was already providing this, but now I have added `logmp_obs` as a returned field for `satpop`.
4. For `logmp0`, the `cenpop` quantity was already providing this, but now I am computing `logmp0_subs` and then concatenating this quantity with the centrals into an array that is returned field as `halopop.logmp0`.

I have added a new unit test, `test_weighted_lc_logmp0_is_consistent_with_logmp_obs`, that enforces expected behavior for the relationship between these two arrays. 
* For centrals, we should always have `logmp_obs<=logmp0`, and this part of the test passes.
* For satelites, we should always have `logmp_obs==logmp0`, because all subhalos should have `t_obs<t0` by definition, and so therefore at the time of observation their masses should have all peaked already. However, I am finding this part of the test fails. See the plot below.
<img width="1082" height="815" alt="subhalo_logmp0_vs_logmp_obs" src="https://github.com/user-attachments/assets/c4160387-ff38-4f88-8618-6629697f9c81" />

@georgezch could you please check whether there is either an issue with the subhalo mass rescaling, or whether I am simply misinterpreting the code?